### PR TITLE
Made flavors and db operations tests work in fake mode.

### DIFF
--- a/scripts/conf/test.conf
+++ b/scripts/conf/test.conf
@@ -1,5 +1,6 @@
 {
     "white_box":false,
+    "fake_mode":false,
     "test_mgmt":false,
     "use_local_ovz":false,
     "use_venv":false,

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -620,12 +620,12 @@ function build_vm() {
 function cmd_build_image() {
     exclaim "Building a image for use with development and integration tests."
     if [ -z "$1" ]
-    then 
+    then
         echo "You must pass an image type to build, like mysql"
         exit 1
     fi
     SERVICE_TYPE=$1
-    
+
 
     USERNAME=`whoami`
     HOMEDIR=`getent passwd $USERNAME | cut -d: -f6`
@@ -770,7 +770,7 @@ function cmd_run_fake() {
     bin/reddwarf-manage --config-file=$CONF_FILE db_sync \
         repo_path=reddwarf_test.sqlite
     sqlite3 reddwarf_test.sqlite \
-        "INSERT INTO service_images VALUES('1','database','fake');"
+        "INSERT INTO service_images VALUES('1','mysql','fake');"
     bin/reddwarf-server --config-file=$CONF_FILE $@ \
         repo_path=reddwarf_test.sqlite
 }

--- a/tests/integration/tests/api/databases.py
+++ b/tests/integration/tests/api/databases.py
@@ -32,9 +32,10 @@ import tests
 from tests import util
 from tests.api.instances import instance_info
 from tests.openvz.dbaas_ovz import TestMysqlAccess
+from tests.util import test_config
 
 GROUP="dbaas.api.databases"
-
+FAKE = test_config.values['fake_mode']
 
 @test(depends_on_classes=[TestMysqlAccess], groups=[tests.DBAAS_API, GROUP,
                                                     tests.INSTANCES])
@@ -63,7 +64,8 @@ class TestDatabases(object):
         databases.append({"name": self.dbname2})
 
         self.dbaas.databases.create(instance_info.id, databases)
-        time.sleep(5)
+        if not FAKE:
+            time.sleep(5)
 
     @test
     def test_create_database_list(self):
@@ -101,7 +103,8 @@ class TestDatabases(object):
     @test
     def test_delete_database(self):
         self.dbaas.databases.delete(instance_info.id, self.dbname_urlencoded)
-        time.sleep(5)
+        if not FAKE:
+            time.sleep(5)
         dbs = self.dbaas.databases.list(instance_info.id)
         found = any(result.name == self.dbname_urlencoded for result in dbs)
         assert_false(found, "Database '%s' SHOULD NOT be found in result" %

--- a/tests/integration/tests/api/flavors.py
+++ b/tests/integration/tests/api/flavors.py
@@ -105,7 +105,7 @@ class Flavors(object):
         for os_flavor in os_flavors:
             found_index = None
             for index, dbaas_flavor in enumerate(dbaas_flavors):
-                if os_flavor.id == dbaas_flavor.id:
+                if os_flavor.name == dbaas_flavor.name:
                     assert_true(found_index is None,
                                 "Flavor ID '%s' appears in elements #%s and #%d." %\
                                 (dbaas_flavor.id, str(found_index), index))

--- a/tests/integration/tests/api/instances.py
+++ b/tests/integration/tests/api/instances.py
@@ -653,7 +653,7 @@ class TestInstanceListing(object):
     @test
     def test_instance_not_deleted_by_other_user(self):
         assert_raises(nova_exceptions.NotFound,
-                     self.daffy_client.instances.get, instance_info.id)
+                      self.daffy_client.instances.get, instance_info.id)
         assert_raises(nova_exceptions.NotFound,
                       self.daffy_client.instances.delete, instance_info.id)
 

--- a/tests/integration/tests/api/instances_actions.py
+++ b/tests/integration/tests/api/instances_actions.py
@@ -50,6 +50,8 @@ if WHITE_BOX:
 
 
 GROUP = "dbaas.api.instances.actions"
+GROUP_REBOOT = "dbaas.api.instances.actions.reboot"
+GROUP_RESTART = "dbaas.api.instances.actions.restart"
 MYSQL_USERNAME = "test_user"
 MYSQL_PASSWORD = "abcde"
 
@@ -194,7 +196,7 @@ class RebootTestBase(object):
         self.test_successful_restart()
 
 
-@test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP],
+@test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP, GROUP_RESTART],
       depends_on_groups=[GROUP_START])
 class RestartTests(RebootTestBase):
     """Tests restarting MySQL."""
@@ -223,7 +225,7 @@ class RestartTests(RebootTestBase):
         self.successful_restart()
 
 
-@test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP],
+@test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP, GROUP_REBOOT],
       depends_on_groups=[GROUP_START], depends_on=[RestartTests])
 class RebootTests(RebootTestBase):
     """Tests restarting instance."""

--- a/tests/integration/tests/openvz/dbaas_ovz.py
+++ b/tests/integration/tests/openvz/dbaas_ovz.py
@@ -59,7 +59,7 @@ class TestMultiNic(object):
         instance_info.user_ip = get_vz_ip_for_device(instance_info.local_id,
                                                       "eth0")
 
-    @test
+    @test(enabled=not test_config.values['fake_mode'])
     def test_get_ip(self):
         # wait for a few seconds for the IP to sync up
         # is there a better way to do this?
@@ -87,7 +87,8 @@ class TestMultiNic(object):
             assert_equal(vz_ip, fixed_ip[0]['address'])
 
 
-@test(depends_on_classes=[TestMultiNic], groups=[GROUP_TEST, "dbaas.guest.mysql"])
+@test(depends_on_classes=[TestMultiNic], groups=[GROUP_TEST, "dbaas.guest.mysql"],
+      enabled=not test_config.values['fake_mode'])
 class TestMysqlAccess(object):
     """
         Make sure that MySQL server was secured.

--- a/tests/integration/tests/util/test_config.py
+++ b/tests/integration/tests/util/test_config.py
@@ -130,6 +130,8 @@ def _setup():
     global test_mgmt
     clean_slate = os.environ.get("CLEAN_SLATE", "False") == "True"
     values = load_configuration()
+    if os.environ.get("FAKE_MODE", "False") == "True":
+        values["fake_mode"] = True
     use_venv = values.get("use_venv", True)
     nova_auth_url = str(values.get("nova_auth_url", "http://localhost:5000/v2.0"))
     reddwarf_auth_url = str(values.get("reddwarf_auth_url", "http://localhost:5000/v1.1"))


### PR DESCRIPTION
- Added a "fake_mode" to test.conf, which gets around things like actually logging into databases if the server is in fake mode.
- Avoided sleeping during the database tests, found different ways to test users.
- Switched to name instead of id for flavors test.
