### PR TITLE
Enabled restart test for black box.

### DIFF
--- a/scripts/redstack
+++ b/scripts/redstack
@@ -893,6 +893,7 @@ function cmd_run_ci() {
 }
 
 function cmd_clear() {
+    cmd_int_tests --group=dbaas.api.instances.delete
     LIST=`virsh -q list|awk '{print $1}'`
     for i in $LIST; do sudo virsh destroy $i; done
     mysql_nova "DELETE FROM instance_info_caches;"

--- a/tests/integration/int_tests.py
+++ b/tests/integration/int_tests.py
@@ -167,6 +167,7 @@ if __name__ == '__main__':
     ADD_DOMAINS = os.environ.get("ADD_DOMAINS", "False") == 'True'
     if not ADD_DOMAINS:
         from tests import initialize
+        from tests.api import delete_all
         from tests.api import flavors
         from tests.api import versions
         from tests.api import instances
@@ -199,6 +200,7 @@ if __name__ == '__main__':
             "services.initialize",
             "dbaas.guest.initialize", #instances.GROUP_START,
             "dbaas.preinstance",
+            "dbaas.api.instances.actions.restart",
             "dbaas.guest.shutdown",
             versions.GROUP,
         ]

--- a/tests/integration/tests/api/delete_all.py
+++ b/tests/integration/tests/api/delete_all.py
@@ -1,0 +1,35 @@
+# Copyright 2011 OpenStack LLC.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from proboscis import test
+
+from tests.util import test_config
+from tests.util import create_dbaas_client
+from tests.util.users import Requirements
+
+
+
+
+GROUP = "dbaas.api.instances.actions"
+
+
+@test(groups=["dbaas.api.instances.delete"])
+def delete_all():
+    """Delete every single one."""
+    user = test_config.users.find_user(Requirements(is_admin=True))
+    dbaas = create_dbaas_client(user)
+    instances = dbaas.instances.list()
+    for instance in instances:
+        instance.delete()

--- a/tests/integration/tests/api/instances.py
+++ b/tests/integration/tests/api/instances.py
@@ -119,10 +119,8 @@ class InstanceTestInfo(object):
         return create_dns_entry(instance_info.local_id, instance_info.id)
 
     def get_address(self):
-        if self.address is None:
-            self.address = db.instance_get_fixed_addresses(
-                context.get_admin_context(), self.get_local_id())
-        return self.address
+        result = self.dbaas.instances.get(self.id)
+        return result.ip[0]
 
     def get_local_id(self):
         if not WHITE_BOX:
@@ -406,7 +404,7 @@ class WaitForGuestInstallationToFinish(object):
     """
 
     @test
-    @time_out(60 * 8)
+    @time_out(60 * 16)
     def test_instance_created(self):
         if WHITE_BOX:
             # Checks the db status as well as the REST API status.


### PR DESCRIPTION
- Added a test that just deletes all the RD instances.
- Increased time out for instance test since it routinely takes more than eight minutes to build.
- Added restart test. Had to make some of the IP bits optional to work with fake mode and without OpenVZ, and skip a tricky scenario.
- Changed the users test to add a database, rather than only add the permission, since dbs weren't showing up otherwise. Not sure how this had worked for so long before.
- Added LocalSqlClient object to the test util module.
