### PR TITLE
Root enabled history

### DIFF
--- a/scripts/conf/test.conf
+++ b/scripts/conf/test.conf
@@ -71,7 +71,7 @@
         }
     ],
     "root_removed_from_instance_api": true,
-    "root_timestamp_disabled": true,
+    "root_timestamp_disabled": false,
     "openvz_disabled": true,
     "management_api_disabled": true,
     "hostname_not_implemented": true,

--- a/tests/integration/int_tests.py
+++ b/tests/integration/int_tests.py
@@ -49,9 +49,6 @@ import unittest
 import sys
 
 
-
-
-
 if os.environ.get("PYDEV_DEBUG", "False") == 'True':
     from pydev import pydevd
     pydevd.settrace('10.0.2.2', port=7864, stdoutToServer=True,
@@ -75,6 +72,7 @@ def add_support_for_localization():
 
 
 MAIN_RUNNER = None
+
 
 def _clean_up():
     """Shuts down any services this program has started and shows results."""
@@ -198,7 +196,7 @@ if __name__ == '__main__':
             databases.GROUP,
             root.GROUP,
             "services.initialize",
-            "dbaas.guest.initialize", #instances.GROUP_START,
+            "dbaas.guest.initialize",  # instances.GROUP_START,
             "dbaas.preinstance",
             "dbaas.api.instances.actions.restart",
             "dbaas.guest.shutdown",
@@ -285,7 +283,6 @@ if __name__ == '__main__':
                     '    %s' % str(test_name).ljust(60))
                 self.stream.flush()
 
-
     class IntegrationTestRunner(NovaTestRunner):
 
         def init(self):
@@ -305,7 +302,8 @@ if __name__ == '__main__':
                 print("Exiting before tests even started.")
             else:
                 if not self.__finished:
-                    print("Tests aborted, trying to print available results...")
+                    msg = "Tests aborted, trying to print available results..."
+                    print(msg)
                     stop_time = time.time()
                     self.__result.printErrors()
                     self.__result.printSummary(self.__start_time, stop_time)
@@ -330,9 +328,9 @@ if __name__ == '__main__':
     MAIN_RUNNER = runner
 
     if repl:
-        # Turn off the following "feature" of the unittest module in case we want
-        # to start a REPL.
-        sys.exit = lambda x : None
+        # Turn off the following "feature" of the unittest module in case
+        # we want to start a REPL.
+        sys.exit = lambda x: None
 
     proboscis.TestProgram(argv=nose_args, groups=groups,
                           testRunner=runner).run_and_exit()

--- a/tests/integration/tests/__init__.py
+++ b/tests/integration/tests/__init__.py
@@ -42,6 +42,7 @@ from tests.util.test_config import clean_slate as CLEAN_SLATE
 
 from tests.util.test_config import test_mgmt as TEST_MGMT
 
+
 # The following decorate a test only if we're doing white box testing.
 def wb_test(home=None, **kwargs):
     if not WHITE_BOX:

--- a/tests/integration/tests/api/databases.py
+++ b/tests/integration/tests/api/databases.py
@@ -34,8 +34,9 @@ from tests.api.instances import instance_info
 from tests.openvz.dbaas_ovz import TestMysqlAccess
 from tests.util import test_config
 
-GROUP="dbaas.api.databases"
+GROUP = "dbaas.api.databases"
 FAKE = test_config.values['fake_mode']
+
 
 @test(depends_on_classes=[TestMysqlAccess], groups=[tests.DBAAS_API, GROUP,
                                                     tests.INSTANCES])
@@ -49,7 +50,7 @@ class TestDatabases(object):
 
     dbname2 = "seconddb"
     created_dbs = [dbname, dbname2]
-    system_dbs = ['information_schema','mysql', 'lost+found']
+    system_dbs = ['information_schema', 'mysql', 'lost+found']
 
     @before_class
     def setUp(self):
@@ -85,7 +86,8 @@ class TestDatabases(object):
         found = False
         for db in self.system_dbs:
             found = any(result.name == db for result in databases)
-            assert_false(found, "Database '%s' SHOULD NOT be found in result" % db)
+            msg = "Database '%s' SHOULD NOT be found in result" % db
+            assert_false(found, msg)
             found = False
 
     @test
@@ -113,7 +115,9 @@ class TestDatabases(object):
     @test
     def test_database_name_too_long(self):
         databases = []
-        databases.append({"name": "aasdlkhaglkjhakjdkjgfakjgadgfkajsg34523dfkljgasldkjfglkjadsgflkjagsdd"})
+        name = ("aasdlkhaglkjhakjdkjgfakjgadgfkajsg"
+                "34523dfkljgasldkjfglkjadsgflkjagsdd")
+        databases.append({"name": name})
         assert_raises(nova_exceptions.BadRequest, self.dbaas.databases.create,
                       instance_info.id, databases)
 

--- a/tests/integration/tests/api/delete_all.py
+++ b/tests/integration/tests/api/delete_all.py
@@ -20,8 +20,6 @@ from tests.util import create_dbaas_client
 from tests.util.users import Requirements
 
 
-
-
 GROUP = "dbaas.api.instances.actions"
 
 

--- a/tests/integration/tests/api/mgmt/accounts.py
+++ b/tests/integration/tests/api/mgmt/accounts.py
@@ -30,7 +30,7 @@ from tests.util import test_config
 from tests.util import create_dbaas_client
 from tests.util.users import Requirements
 
-GROUP="dbaas.api.mgmt.accounts"
+GROUP = "dbaas.api.mgmt.accounts"
 
 
 @test(groups=[tests.DBAAS_API, GROUP, tests.PRE_INSTANCES],

--- a/tests/integration/tests/api/mgmt/admin_required.py
+++ b/tests/integration/tests/api/mgmt/admin_required.py
@@ -62,7 +62,10 @@ class TestAdminRequired(object):
 
     @test
     def test_mgmt_show(self):
-        """ A regular user may not view the management details of any instance. """
+        """
+        A regular user may not view the management details
+        of any instance.
+        """
         assert_raises(Unauthorized, self.dbaas.management.show, 0)
 
     @test
@@ -88,4 +91,3 @@ class TestAdminRequired(object):
     def test_diagnostics_get(self):
         """ A regular user may not view the diagnostics. """
         assert_raises(Unauthorized, self.dbaas.diagnostics.get, 0)
-

--- a/tests/integration/tests/api/mgmt/hosts.py
+++ b/tests/integration/tests/api/mgmt/hosts.py
@@ -30,7 +30,7 @@ from tests.util import test_config
 from tests.util import create_dbaas_client
 from tests.util.users import Requirements
 
-GROUP="dbaas.api.mgmt.hosts"
+GROUP = "dbaas.api.mgmt.hosts"
 
 
 @test(groups=[tests.DBAAS_API, GROUP, tests.PRE_INSTANCES],
@@ -52,9 +52,10 @@ class HostsBeforeInstanceCreation(object):
         assert_equal(len(host_index_result), 1,
                     "list hosts length should be one: %r" %
                     host_index_result[0])
-        assert_equal(int(host_index_result[0].instanceCount), 0,
-                     "'host' instance count should have 0 running instances: %r"
-                     % host_index_result[0].instanceCount)
+
+        msg = ("'host' instance count should have 0 running instances: %r" %
+               host_index_result[0].instanceCount)
+        assert_equal(int(host_index_result[0].instanceCount), 0, msg)
         for host in list(enumerate(host_index_result, start=1)):
             print("%r host: %r" % (host[0], host[1]))
             self.host = host[1]
@@ -80,7 +81,8 @@ class HostsBeforeInstanceCreation(object):
 
     @test(enabled=create_new_instance())
     def test_host_not_found(self):
-        assert_raises(exceptions.NotFound, self.client.hosts.get, "host@$%3dne")
+        hostname = "host@$%3dne"
+        assert_raises(exceptions.NotFound, self.client.hosts.get, hostname)
 
 
 @test(groups=[tests.INSTANCES, GROUP], depends_on_groups=["dbaas.listing"],
@@ -98,9 +100,9 @@ class HostsAfterInstanceCreation(object):
         myresult = self.client.hosts.index()
         assert_true(len(myresult) > 0,
                         "list hosts should not be empty: %s" % str(myresult))
-        assert_equal(myresult[0].instanceCount, 1,
-                     "instance count of 'host' should have 1 running instances: %r"
-                     % myresult[0].instanceCount)
+        msg = ("instance count of 'host' should have 1 running instances: %r" %
+               myresult[0].instanceCount)
+        assert_equal(myresult[0].instanceCount, 1, msg)
         for index, host in enumerate(myresult, start=1):
             print("%d host: %s" % (index, host))
             self.host = host

--- a/tests/integration/tests/api/mgmt/instances.py
+++ b/tests/integration/tests/api/mgmt/instances.py
@@ -32,7 +32,7 @@ if WHITE_BOX:
     from nova import context
 
 
-GROUP="dbaas.api.mgmt.instances"
+GROUP = "dbaas.api.mgmt.instances"
 
 
 @test(depends_on_classes=[CreateInstance], groups=[GROUP])
@@ -41,13 +41,17 @@ class MgmtInstancesIndex(object):
 
     @before_class
     def setUp(self):
-        self.admin_user = test_config.users.find_user(Requirements(is_admin=True))
+        reqs = Requirements(is_admin=True)
+        self.admin_user = test_config.users.find_user(reqs)
         self.admin_client = create_dbaas_client(self.admin_user)
-        self.admin_context = context.RequestContext(self.admin_user.auth_user, self.admin_user.tenant)
+        self.admin_context = context.RequestContext(self.admin_user.auth_user,
+                                                    self.admin_user.tenant)
 
-        self.user = test_config.users.find_user(Requirements(is_admin=False))
+        reqs = Requirements(is_admin=False)
+        self.user = test_config.users.find_user(reqs)
         self.client = create_dbaas_client(self.user)
-        self.context = context.RequestContext(self.user.auth_user, self.user.tenant)
+        self.context = context.RequestContext(self.user.auth_user,
+                                              self.user.tenant)
 
     @test
     def test_mgmt_instance_index_as_user_fails(self):
@@ -56,7 +60,9 @@ class MgmtInstancesIndex(object):
 
     @test
     def test_mgmt_instance_index_fields_present(self):
-        """ Verify that all the expected fields are returned by the index method. """
+        """
+        Verify that all the expected fields are returned by the index method.
+        """
         expected_fields = [
                 'account_id',
                 'id',
@@ -76,13 +82,18 @@ class MgmtInstancesIndex(object):
 
     @test
     def test_mgmt_instance_index_check_filter(self):
-        """ Make sure that the deleted= filter works as expected, and no instances are excluded. """
+        """
+        Make sure that the deleted= filter works as expected, and no instances
+        are excluded.
+        """
         instance_counts = []
         for deleted_filter in (True, False):
-            filtered_index = self.admin_client.management.index(deleted=deleted_filter)
+            filtered_index = self.admin_client.management.index(
+                deleted=deleted_filter)
             instance_counts.append(len(filtered_index))
             for instance in filtered_index:
-                # Every instance listed here should have the proper value for 'deleted'.
+                # Every instance listed here should have the proper value
+                # for 'deleted'.
                 assert_equal(deleted_filter, instance.deleted)
         full_index = self.admin_client.management.index()
         # There should be no instances that are neither deleted or not-deleted.

--- a/tests/integration/tests/api/mgmt/instances.py
+++ b/tests/integration/tests/api/mgmt/instances.py
@@ -87,4 +87,3 @@ class MgmtInstancesIndex(object):
         full_index = self.admin_client.management.index()
         # There should be no instances that are neither deleted or not-deleted.
         assert_equal(len(full_index), sum(instance_counts))
-        

--- a/tests/integration/tests/api/mgmt/storage.py
+++ b/tests/integration/tests/api/mgmt/storage.py
@@ -29,7 +29,7 @@ from tests.util import test_config
 from tests.util import create_dbaas_client
 from tests.util.users import Requirements
 
-GROUP="dbaas.api.mgmt.storage"
+GROUP = "dbaas.api.mgmt.storage"
 
 
 @test(groups=[tests.DBAAS_API, GROUP, tests.PRE_INSTANCES],
@@ -73,7 +73,9 @@ class StorageAfterInstanceCreation(object):
             CheckInstance(None).attrs_exist(device._info, expected_attrs,
                                             msg="Storage")
             assert_equal(device.name, instance_info.storage[index].name)
-            assert_equal(device.totalsize, instance_info.storage[index].totalsize)
+            instance_totalsize = instance_info.storage[index].totalsize
+            assert_equal(device.totalsize, instance_totalsize)
             assert_equal(device.type, instance_info.storage[index].type)
-            avail = instance_info.storage[index].availablesize - instance_info.volume['size']
+            avail = instance_info.storage[index].availablesize
+            avail -= instance_info.volume['size']
             assert_equal(device.availablesize, avail)

--- a/tests/integration/tests/api/root.py
+++ b/tests/integration/tests/api/root.py
@@ -57,20 +57,16 @@ class TestRoot(object):
         self.dbaas_admin = util.create_dbaas_client(instance_info.admin_user)
 
     def _verify_root_timestamp(self, id):
-        mgmt_instance = self.dbaas_admin.management.show(id)
+        mgmt_instance = self.dbaas.instances.get(id)
         assert_true(mgmt_instance is not None)
         timestamp = mgmt_instance.root_enabled_at
         assert_equal(self.root_enabled_timestamp, timestamp)
-        reh = self.dbaas_admin.management.root_enabled_history(id)
-        print "Root_enabled_history is %s" % reh
-        timestamp = reh.root_enabled_at
-        assert_equal(self.root_enabled_timestamp, timestamp)
-        assert_equal(id, reh.id)
 
     def _root(self):
         global root_password
         host = "%"
         user, password = self.dbaas.root.create(instance_info.id)
+        self.root_enabled_timestamp = self.dbaas.instances.get(instance_info.id).root_enabled_at
 
     def _root_local_sql(self):
         engine = init_engine(user, password, instance_info.user_ip)
@@ -82,7 +78,7 @@ class TestRoot(object):
                 assert_equal(user, row['User'])
                 assert_equal(host, row['Host'])
         root_password = password
-        self.root_enabled_timestamp = self.dbaas_admin.management.show(instance_info.id).root_enabled_at
+        self.root_enabled_timestamp = self.dbaas.instances.get(instance_info.id).root_enabled_at
         assert_not_equal(self.root_enabled_timestamp, 'Never')
 
     @test
@@ -102,7 +98,7 @@ class TestRoot(object):
         assert_equal(self.root_enabled_timestamp, 'Never')
 
     @test(depends_on=[test_root_initially_disabled_details])
-    def test_root_disabeld_in_mgmt_api(self):
+    def test_root_disabled_in_mgmt_api(self):
         """Verifies in the management api that the timestamp exists"""
         if test_config.values['management_api_disabled']:
             raise SkipTest("Management api not enabled yet")

--- a/tests/integration/tests/api/root.py
+++ b/tests/integration/tests/api/root.py
@@ -38,7 +38,7 @@ if WHITE_BOX:
     from sqlalchemy.sql.expression import text
     from reddwarf.guest.dbaas import LocalSqlClient
 
-GROUP="dbaas.api.root"
+GROUP = "dbaas.api.root"
 
 
 @test(depends_on_classes=[TestUsers], groups=[tests.DBAAS_API, GROUP,
@@ -66,19 +66,22 @@ class TestRoot(object):
         global root_password
         host = "%"
         user, password = self.dbaas.root.create(instance_info.id)
-        self.root_enabled_timestamp = self.dbaas.instances.get(instance_info.id).root_enabled_at
+        instance = self.dbaas.instances.get(instance_info.id)
+        self.root_enabled_timestamp = instance.root_enabled_at
 
     def _root_local_sql(self):
         engine = init_engine(user, password, instance_info.user_ip)
         client = LocalSqlClient(engine)
         with client:
-            t = text("""SELECT User, Host FROM mysql.user WHERE User=:user AND Host=:host;""")
+            t = text("""SELECT User, Host FROM mysql.user """
+                     """WHERE User=:user AND Host=:host;""")
             result = client.execute(t, user=user, host=host)
             for row in result:
                 assert_equal(user, row['User'])
                 assert_equal(host, row['Host'])
         root_password = password
-        self.root_enabled_timestamp = self.dbaas.instances.get(instance_info.id).root_enabled_at
+        instance = self.dbaas.instances.get(instance_info.id)
+        self.root_enabled_timestamp = instance.root_enabled_at
         assert_not_equal(self.root_enabled_timestamp, 'Never')
 
     @test
@@ -149,7 +152,8 @@ class TestRoot(object):
     @test(depends_on=[test_root_still_enabled],
           enabled=not test_config.values['root_removed_from_instance_api'])
     def test_root_still_enabled_details(self):
-        """Use instance details to test that after root was reset it's still enabled."""
+        """Use instance details to test that after root was reset,
+        it's still enabled."""
         instance = self.dbaas.instances.get(instance_info.id)
         assert_true(hasattr(instance, 'rootEnabled'),
                     "Instance has no rootEnabled property.")
@@ -161,7 +165,7 @@ class TestRoot(object):
     def test_reset_root_user_enabled(self):
         if test_config.values['root_timestamp_disabled']:
             raise SkipTest("Enabled timestamp not enabled yet")
-        created_users= ['root']
+        created_users = ['root']
         self.system_users.remove('root')
         users = self.dbaas.users.list(instance_info.id)
         found = False
@@ -173,7 +177,8 @@ class TestRoot(object):
         found = False
         for user in self.system_users:
             found = any(result.name == user for result in users)
-            assert_false(found, "User '%s' SHOULD NOT BE found in result" % user)
+            msg = "User '%s' SHOULD NOT BE found in result" % user
+            assert_false(found, msg)
             found = False
         assert_not_equal(self.root_enabled_timestamp, 'Never')
         self._verify_root_timestamp(instance_info.id)

--- a/tests/integration/tests/api/root.py
+++ b/tests/integration/tests/api/root.py
@@ -61,6 +61,11 @@ class TestRoot(object):
         assert_true(mgmt_instance is not None)
         timestamp = mgmt_instance.root_enabled_at
         assert_equal(self.root_enabled_timestamp, timestamp)
+        if test_config.values['test_mgmt']:
+            reh = self.dbaas_admin.management.root_enabled_history(id)
+            timestamp = reh.root_enabled_at
+            assert_equal(self.root_enabled_timestamp, timestamp)
+            assert_equal(id, reh.id)
 
     def _root(self):
         global root_password

--- a/tests/integration/tests/api/root.py
+++ b/tests/integration/tests/api/root.py
@@ -146,7 +146,7 @@ class TestRoot(object):
         enabled = self.dbaas.root.is_root_enabled(instance_info.id)
         assert_true(enabled, "Root SHOULD still be enabled.")
 
-    @test(depends_on=[test_root_still_enabled], 
+    @test(depends_on=[test_root_still_enabled],
           enabled=not test_config.values['root_removed_from_instance_api'])
     def test_root_still_enabled_details(self):
         """Use instance details to test that after root was reset it's still enabled."""

--- a/tests/integration/tests/api/users.py
+++ b/tests/integration/tests/api/users.py
@@ -36,7 +36,7 @@ from tests.util import process
 from tests import util
 from tests.util import test_config
 
-GROUP="dbaas.api.users"
+GROUP = "dbaas.api.users"
 FAKE = test_config.values['fake_mode']
 
 
@@ -75,7 +75,6 @@ class TestUsers(object):
         self.dbaas.databases.delete(instance_info.id, self.db1)
         self.dbaas.databases.delete(instance_info.id, self.db2)
 
-
     @test()
     def test_create_users(self):
         users = []
@@ -112,7 +111,8 @@ class TestUsers(object):
         found = False
         for user in self.system_users:
             found = any(result.name == user for result in users)
-            assert_false(found, "User '%s' SHOULD NOT BE found in result" % user)
+            msg = "User '%s' SHOULD NOT BE found in result" % user
+            assert_false(found, msg)
             found = False
 
     @test(depends_on=[test_create_users_list])
@@ -168,7 +168,7 @@ class TestUsers(object):
                       instance_info.id, users)
 
     @test(enabled=False)
-    #TODO(hub_cap): Make this test work once python-routes is updated, if ever...
+    #TODO(hub_cap): Make this test work once python-routes is updated, if ever.
     def test_delete_user_with_period_in_name(self):
         """Attempt to create/destroy a user with a period in its name"""
         users = []

--- a/tests/integration/tests/api/versions.py
+++ b/tests/integration/tests/api/versions.py
@@ -21,7 +21,7 @@ from tests.util import test_config
 from tests.util import create_dbaas_client
 from tests.util.users import Requirements
 
-GROUP="dbaas.api.versions"
+GROUP = "dbaas.api.versions"
 
 
 @test(groups=[tests.DBAAS_API, GROUP, tests.PRE_INSTANCES, 'DBAAS_VERSIONS'],
@@ -48,7 +48,8 @@ class Versions(object):
     def _request(self, url, method='GET', response='200'):
         resp, body = None, None
         try:
-            resp, body = self.client.client.request('http://localhost:8775' + url, method)
+            full_url = 'http://localhost:8775' + url
+            resp, body = self.client.client.request(full_url, method)
             assert_equal(resp.get('status', ''), response)
         except Exception:
             pass

--- a/tests/integration/tests/compute/guest_initialize_failure.py
+++ b/tests/integration/tests/compute/guest_initialize_failure.py
@@ -17,7 +17,7 @@ import time
 from tests import util
 
 
-GROUP='dbaas.guest.initialize.failure'
+GROUP = 'dbaas.guest.initialize.failure'
 
 from proboscis import after_class
 from proboscis import before_class
@@ -57,7 +57,7 @@ if WHITE_BOX:
     from reddwarf.api.common import dbaas_mapping
     from reddwarf.db import api as dbapi
     from reddwarf.utils import poll_until
-    from reddwarf.scheduler import simple # import used for FLAG values
+    from reddwarf.scheduler import simple  # import used for FLAG values
     from nova import flags
     from reddwarf.compute.manager import ReddwarfInstanceMetaData
     FLAGS = flags.FLAGS
@@ -130,14 +130,14 @@ class VerifyManagerAbortsInstanceWhenVolumeFails(InstanceTest):
         test_config.volume_service.start()
         restart_compute_service()
         if self.instance_exists:
-            self.db.instance_destroy(context.get_admin_context(), self.local_id)
-
+            self.db.instance_destroy(context.get_admin_context(),
+                                     self.local_id)
 
     @test
     def create_instance(self):
         """Create a new instance."""
         self.abort_count = count_notifications(notifier.ERROR,
-                                               "reddwarf.instance.abort.volume")
+            "reddwarf.instance.abort.volume")
         self._create_instance()
         # Use an admin context to avoid the possibility that in between the
         # previous line and this one the request goes through and the instance
@@ -154,7 +154,6 @@ class VerifyManagerAbortsInstanceWhenVolumeFails(InstanceTest):
         abort_count2 = count_notifications(notifier.ERROR,
                                            "reddwarf.instance.abort.volume")
         assert_true(self.abort_count < abort_count2)
-
 
     @test(depends_on=[wait_for_failure])
     @time_out(2 * 60)
@@ -178,6 +177,7 @@ class VerifyManagerAbortsInstanceWhenVolumeFails(InstanceTest):
 #TODO: Find some way to get the compute instance creation to fail.
 
 GUEST_INSTALL_TIMEOUT = 60 * 2
+
 
 @test(groups=[GROUP, GROUP + ".guest"],
       depends_on_groups=["services.initialize"])
@@ -234,8 +234,9 @@ class VerifyManagerAbortsInstanceWhenGuestInstallFails(InstanceTest):
         while pid is None:
             guest_status = dbapi.guest_status_get(self.local_id)
             rest_api_result = self.dbaas.instances.get(self.id)
-            out, err = process("pstree -ap | grep init | cut -d',' -f2 | vzpid - | grep %s | awk '{print $1}'"
-                                % str(self.local_id))
+            cmd = ("pstree -ap | grep init | cut -d',' -f2 | vzpid - | "
+                   "grep %s | awk '{print $1}'")
+            out, err = process(cmd % str(self.local_id))
             pid = out.strip()
             if not pid:
                 # Make sure the guest status is BUILDING during this time.

--- a/tests/integration/tests/dns/check_domain.py
+++ b/tests/integration/tests/dns/check_domain.py
@@ -42,9 +42,9 @@ if WHITE_BOX:
     from reddwarf.dns.rsdns.driver import RsDnsZone
     from reddwarf.utils import poll_until
     FLAGS = flags.FLAGS
-    TEST_CONTENT="126.1.1.1"
-    TEST_NAME="hiwassup.%s" % FLAGS.dns_domain_name
-    DNS_DOMAIN_ID=None
+    TEST_CONTENT = "126.1.1.1"
+    TEST_NAME = "hiwassup.%s" % FLAGS.dns_domain_name
+    DNS_DOMAIN_ID = None
 
 
 @wb_test(groups=["rsdns.domains", "rsdns.show_entries"])
@@ -91,6 +91,7 @@ class RsDnsDriverTests(object):
         """Make sure the domain in the FLAGS exists."""
         self.driver = RsDnsDriver(raise_if_zone_missing=False)
         assert_not_equal(None, self.driver.default_dns_zone)
+
         def zone_found():
             zones = self.driver.get_dns_zones()
             print("Retrieving zones.")
@@ -125,9 +126,9 @@ class RsDnsDriverTests(object):
                 self.driver.delete_entry(name=entry.name, type=entry.type,
                                          dns_zone=entry.dns_zone)
         # It takes awhile for them to be deleted.
-        poll_until(lambda : self.driver.get_entries_by_name(TEST_NAME),
-                         lambda list : len(list) == 0,
-                         sleep_time=4, time_out=60)
+        poll_until(lambda: self.driver.get_entries_by_name(TEST_NAME),
+                   lambda list: len(list) == 0,
+                   sleep_time=4, time_out=60)
 
     @test(depends_on=[delete_all_entries])
     def create_test_entry(self):
@@ -165,6 +166,6 @@ class RsDnsDriverTests(object):
         fullname = TEST_NAME
         self.driver.delete_entry(fullname, "A")
         # It takes awhile for them to be deleted.
-        poll_until(lambda : self.driver.get_entries_by_name(TEST_NAME),
-                         lambda list : len(list) == 0,
-                         sleep_time=2, time_out=60)
+        poll_until(lambda: self.driver.get_entries_by_name(TEST_NAME),
+                   lambda list: len(list) == 0,
+                   sleep_time=2, time_out=60)

--- a/tests/integration/tests/dns/concurrency.py
+++ b/tests/integration/tests/dns/concurrency.py
@@ -19,7 +19,8 @@ string:
 Second simultaneous read on fileno 5 detected.  Unless you really know what
 you're doing, make sure that only one greenthread can read any particular
 socket.  Consider using a pools.Pool. If you do know what you're doing and want
-to disable this error, call eventlet.debug.hub_multiple_reader_prevention(False)
+to disable this error, call
+eventlet.debug.hub_multiple_reader_prevention(False)
 
 It is perhaps the most helpful error message ever created.
 
@@ -47,12 +48,14 @@ if WHITE_BOX:
     from nova import utils
     FLAGS = flags.FLAGS
 
+
 @test(groups=["rsdns.eventlet"])
 class RsdnsEventletTests(object):
     """Makes sure the RSDNS client can be used from multiple green threads."""
 
     def assert_record_created(self, index):
-        assert_true(index in self.new_records, "Record %d wasn't created!" % index)
+        msg = "Record %d wasn't created!" % index
+        assert_true(index in self.new_records, msg)
 
     @before_class(enabled=WHITE_BOX and should_run_rsdns_tests())
     def create_driver(self):
@@ -65,7 +68,7 @@ class RsdnsEventletTests(object):
     def make_record(self, index):
         """Creates a record with the form 'eventlet-%s-%d'."""
         uuid = "eventlet-%s-%d" % (self.test_uuid, index)
-        instance = { 'uuid':uuid }
+        instance = {'uuid': uuid}
         entry = self.entry_factory.create_entry(instance)
         entry.name = uuid + "." + self.entry_factory.default_dns_zone.name
         entry.content = "123.123.123.123"
@@ -84,6 +87,7 @@ class RsdnsEventletTests(object):
     def use_dns_from_multiple_greenthreads(self):
         """Add multiple DNS records at once."""
         self.new_records = {}
+
         def make_record(index):
             def __cb():
                 self.make_record(index)

--- a/tests/integration/tests/dns/conversion.py
+++ b/tests/integration/tests/dns/conversion.py
@@ -32,8 +32,8 @@ if WHITE_BOX:
     FLAGS = flags.FLAGS
     driver = None
     DEFAULT_ZONE = RsDnsZone(1, "dbaas.rackspace.org")
-    TEST_CONTENT="126.1.1.1"
-    TEST_NAME="hiwassup.dbaas.rackspace.org"
+    TEST_CONTENT = "126.1.1.1"
+    TEST_NAME = "hiwassup.dbaas.rackspace.org"
 
 
 @wb_test(groups=["unit", "rsdns.conversion"])
@@ -42,7 +42,6 @@ class ConvertingNovaEntryNamesToRecordNames(unittest.TestCase):
     def setUp(self):
         self.converter = EntryToRecordConverter(DEFAULT_ZONE)
         self.fake_zone = RsDnsZone(id=5, name="blah.org")
-
 
     def test_normal_name(self):
         long_name = self.converter.name_to_long_name("hi", self.fake_zone)
@@ -65,11 +64,11 @@ class ConvertingRecordsToEntries(unittest.TestCase):
         self.converter = EntryToRecordConverter(DEFAULT_ZONE)
         self.fake_zone = RsDnsZone(id=5, name="blah.org")
 
-
     def test_normal_name(self):
-        record = Record(None, {"id":5, "name":"hi.blah.org",
-                               "data":"stacker.com blah@blah 13452378", "ttl":5,
-                               "type":"SOA"})
+        record = Record(None, {"id": 5, "name": "hi.blah.org",
+                               "data": "stacker.com blah@blah 13452378",
+                               "ttl": 5,
+                               "type": "SOA"})
         entry = self.converter.record_to_entry(record=record,
                                                dns_zone=self.fake_zone)
         self.assertEqual("stacker.com blah@blah 13452378", entry.content)
@@ -87,7 +86,7 @@ class WhenCreatingAnEntryForAnInstance(unittest.TestCase):
         self.creator = RsDnsInstanceEntryFactory()
 
     def test_should_concatanate_strings(self):
-        instance = {'id':'56',
+        instance = {'id': '56',
                     'uuid': '000136c0-effa-4711-a747-a5b9fbfcb3bd'}
         entry = self.creator.create_entry(instance)
         expected_name = "%s.%s" % (hashlib.sha1(instance['uuid']).hexdigest(),

--- a/tests/integration/tests/dns/dns.py
+++ b/tests/integration/tests/dns/dns.py
@@ -55,7 +55,7 @@ class WhenInstanceIsCreated(unittest.TestCase):
                 return dns_driver.get_entries_by_name(entry.name)
             try:
                 poll_until(get_entries, lambda entries: len(entries) > 0,
-                                 sleep_time=2, time_out = 60)
+                           sleep_time=2, time_out=60)
             except exception.PollTimeOut:
                 self.fail("Did not find name " + entry.name + \
                           " in the entries, which were as follows:"
@@ -83,8 +83,8 @@ class AfterInstanceIsDestroyed(unittest.TestCase):
             return dns_driver.get_entries_by_name(entry.name)
 
         try:
-            poll_until(get_entries, lambda entries : len(entries) == 0,
-                             sleep_time=2, time_out=60)
+            poll_until(get_entries, lambda entries: len(entries) == 0,
+                       sleep_time=2, time_out=60)
         except exception.PollTimeOut:
             # Manually delete the rogue item
             dns_driver.delete_entry(entry.name, entry.type, entry.dns_zone)

--- a/tests/integration/tests/guest/amqp_restarts.py
+++ b/tests/integration/tests/guest/amqp_restarts.py
@@ -59,6 +59,7 @@ if WHITE_BOX:
 def topic_name():
     return "guest.%s" % test_config.values['host_name']
 
+
 class Rabbit(object):
 
     def declare_queue(self, topic):
@@ -120,6 +121,7 @@ class WhenAgentRunsAsRabbitGoesUpAndDown(object):
 
     def _send(self):
         original_queue_count = self.rabbit.get_queue_items()
+
         @time_out(5)
         def send_msg_with_timeout():
             self.rabbit.declare_queue(topic_name())
@@ -128,7 +130,7 @@ class WhenAgentRunsAsRabbitGoesUpAndDown(object):
                     {"method": "version",
                      "args": {"package_name": "dpkg"}
                 })
-            return { "status":"good", "version": version }
+            return {"status": "good", "version": version}
         try:
             return send_msg_with_timeout()
         except Exception as e:
@@ -146,12 +148,13 @@ class WhenAgentRunsAsRabbitGoesUpAndDown(object):
             # tolerate one such bug but no more.
             if not isinstance(e, TimeoutError):
                 self.send_after_reconnect_errors += 1
-                if self.send_after_reconnect_errors > self.tolerated_send_errors:
+                errors = self.send_after_reconnect_errors
+                if errors > self.tolerated_send_errors:
                     fail("Exception while making RPC call: %s" % e)
             if self.rabbit.get_queue_items() > original_queue_count:
-                return { "status":"bad", "blame":"agent"}
+                return {"status": "bad", "blame": "agent"}
             else:
-                return { "status":"bad", "blame":"host"}
+                return {"status": "bad", "blame": "host"}
 
     def _send_allow_for_host_bug(self):
         while True:
@@ -297,7 +300,3 @@ class WhenAgentRunsAsRabbitGoesUpAndDown(object):
     def send_message_again_2b(self):
         """The agent should be able to receive messages after reconnecting."""
         self.send_message()
-
-
-
-

--- a/tests/integration/tests/initialize.py
+++ b/tests/integration/tests/initialize.py
@@ -50,26 +50,34 @@ success_statuses = ["build", "active"]
 def dbaas_url():
     return str(test_config.values.get("dbaas_url"))
 
+
 def glance_api_conf():
     return str(test_config.values.get("glance_api_conf"))
+
 
 def glance_reg_conf():
     return str(test_config.values.get("glance_reg_conf"))
 
+
 def keystone_conf():
     return str(test_config.values.get("keystone_conf"))
+
 
 def nova_conf():
     return str(test_config.values.get("nova_conf"))
 
+
 def nova_url():
     return str(test_config.values.get("nova_url"))
+
 
 def either_web_service_is_up():
     return test_config.dbaas.is_service_alive() or \
            test_config.nova.is_service_alive()
 
+
 install_image = False
+
 
 @test(groups=["services.initialize", "services.initialize.glance"])
 class GlanceRegistry(unittest.TestCase):
@@ -81,11 +89,12 @@ class GlanceRegistry(unittest.TestCase):
         else:
             reg_path = "/usr/bin/glance-registry"
         self.service = Service(python_cmd_list() +
-                               [reg_path, glance_reg_conf() ])
+                               [reg_path, glance_reg_conf()])
 
     def test_start(self):
         if not either_web_service_is_up():
             self.service.start()
+
 
 @test(groups=["services.initialize", "services.initialize.glance"],
       depends_on_classes=[GlanceRegistry])
@@ -98,11 +107,12 @@ class GlanceApi(unittest.TestCase):
         else:
             reg_path = "/usr/bin/glance-api"
         self.service = Service(python_cmd_list() +
-                               [reg_path, glance_api_conf() ])
+                               [reg_path, glance_api_conf()])
 
     def test_start(self):
         if not either_web_service_is_up():
             self.service.start()
+
 
 @test(groups=["services.initialize", "services.initialize.glance"],
       depends_on_classes=[GlanceApi])
@@ -133,7 +143,7 @@ class Network(unittest.TestCase):
     def setUp(self):
         self.service = Service(python_cmd_list() +
                                ["%s/bin/nova-network" % nova_code_root(),
-                                "--flagfile=%s" % nova_conf() ])
+                                "--flagfile=%s" % nova_conf()])
 
     def test_start(self):
         if not either_web_service_is_up():
@@ -147,7 +157,7 @@ class Dns(unittest.TestCase):
     def setUp(self):
         self.service = Service(python_cmd_list() +
                                ["%s/bin/nova-dns" % nova_code_root(),
-                                "--flagfile=%s" % nova_conf() ])
+                                "--flagfile=%s" % nova_conf()])
 
     def test_start(self):
         if not either_web_service_is_up():
@@ -161,7 +171,7 @@ class Scheduler(unittest.TestCase):
     def setUp(self):
         self.service = Service(python_cmd_list() +
                                ["%s/bin/nova-scheduler" % nova_code_root(),
-                                "--flagfile=%s" % nova_conf() ])
+                                "--flagfile=%s" % nova_conf()])
 
     def test_start(self):
         if not either_web_service_is_up():
@@ -221,6 +231,7 @@ class KeystoneAdmin(unittest.TestCase):
         if not self.service.is_service_alive():
             self.service.start()
 
+
 @test(groups=["services.initialize"],
       depends_on_classes=[KeystoneAPI], enabled=KEYSTONE_ALL)
 class KeystoneAll(unittest.TestCase):
@@ -245,7 +256,7 @@ class Reaper(unittest.TestCase):
     def setUp(self):
         self.service = Service(python_cmd_list() +
                                ["%s/bin/nova-reaper" % nova_code_root(),
-                                "--flagfile=%s" % nova_conf() ])
+                                "--flagfile=%s" % nova_conf()])
 
     def test_start(self):
         if not self.service.is_service_alive():
@@ -309,8 +320,9 @@ class ServicesTestable(unittest.TestCase):
         ServicesUp - Check that default networks have a host assigned
         """
         while(True):
-            networks = dbapi.network_get_all_by_host(context.get_admin_context(),
-                                                     socket.gethostname())
+            get_all = dbaapi.network_get_all_by_host
+            hostname = socket.gethostname()
+            networks = get_all(context.get_admin_context(), hostname)
             if len(networks) == 1:
                 return
             time.sleep(5)
@@ -325,4 +337,3 @@ class StartAndWait(unittest.TestCase):
         import time
         while(True):
             time.sleep(2)
-

--- a/tests/integration/tests/openvz/compute_reboot_vz.py
+++ b/tests/integration/tests/openvz/compute_reboot_vz.py
@@ -16,7 +16,7 @@
 import time
 from tests import util
 
-GROUP='dbaas.compute.reboot.vz'
+GROUP = 'dbaas.compute.reboot.vz'
 
 from novaclient.exceptions import NotFound
 
@@ -62,10 +62,11 @@ if WHITE_BOX:
     from reddwarf.api.common import dbaas_mapping
     from reddwarf.db import api as dbapi
     from reddwarf.utils import poll_until
-    from reddwarf.scheduler import simple # import used for FLAG values
+    from reddwarf.scheduler import simple  # import used for FLAG values
     from reddwarf.compute.manager import ReddwarfInstanceMetaData
 
     FLAGS = flags.FLAGS
+
 
 @test(depends_on_groups=[GROUP_START], groups=[GROUP_TEST, GROUP])
 class VerifyRebootRestartsTheVZ(InstanceTest):
@@ -82,7 +83,7 @@ class VerifyRebootRestartsTheVZ(InstanceTest):
     def ensure_vz_power_state(self, power_state):
         """Ensures the database has the correct state"""
         poll_until(self._get_compute_instance_state,
-                   lambda state : state == power_state,
+                   lambda state: state == power_state,
                    sleep_time=2, time_out=60)
 
     def ensure_vz_actual_state(self, power_state):
@@ -90,7 +91,7 @@ class VerifyRebootRestartsTheVZ(InstanceTest):
         def get_info_from_conn():
             return self.conn.get_info(self.name)['state']
         poll_until(get_info_from_conn,
-                   lambda state : state == power_state,
+                   lambda state: state == power_state,
                    sleep_time=2, time_out=60)
 
     def stop_vz(self):

--- a/tests/integration/tests/openvz/dbaas_ovz.py
+++ b/tests/integration/tests/openvz/dbaas_ovz.py
@@ -45,6 +45,7 @@ if WHITE_BOX:
     from nova import context
     from nova import db
 
+
 @test(depends_on_groups=[GROUP_START], groups=[GROUP_TEST, "dbaas.guest.ovz"])
 class TestMultiNic(object):
     """
@@ -77,17 +78,19 @@ class TestMultiNic(object):
         Multinic - Verify that nics as specified in the database are created
         in the guest
         """
-        vifs = db.virtual_interface_get_by_instance(context.get_admin_context(),
+        admin_context = context.get_admin_context()
+        vifs = db.virtual_interface_get_by_instance(admin_context(),
                                                     instance_info.local_id)
         for vif in vifs:
-            fixed_ip = db.fixed_ip_get_by_virtual_interface(context.get_admin_context(),
+            fixed_ip = db.fixed_ip_get_by_virtual_interface(admin_context(),
                                                             vif['id'])
             vz_ip = get_vz_ip_for_device(instance_info.local_id,
                                          vif['network']['bridge_interface'])
             assert_equal(vz_ip, fixed_ip[0]['address'])
 
 
-@test(depends_on_classes=[TestMultiNic], groups=[GROUP_TEST, "dbaas.guest.mysql"],
+@test(depends_on_classes=[TestMultiNic],
+      groups=[GROUP_TEST, "dbaas.guest.mysql"],
       enabled=not test_config.values['fake_mode'])
 class TestMysqlAccess(object):
     """

--- a/tests/integration/tests/reaper/volume_reaping.py
+++ b/tests/integration/tests/reaper/volume_reaping.py
@@ -49,6 +49,7 @@ if WHITE_BOX:
 
 GROUP = 'reddwarf.reaper'
 
+
 @test(groups=[GROUP, GROUP + ".volume"],
       depends_on_groups=["services.initialize"])
 class ReaperShouldKillOlderUnattachedVolumes(InstanceTest):
@@ -88,7 +89,7 @@ class ReaperShouldKillOlderUnattachedVolumes(InstanceTest):
         expiration_time = FLAGS.reddwarf_reaper_orphan_volume_expiration_time
         updated_at = utils.utcnow() - timedelta(seconds=expiration_time * 2)
         db_api.volume_update(context.get_admin_context(), self.volume_id,
-                            {"updated_at":updated_at})
+                            {"updated_at": updated_at})
 
     @test(depends_on=[make_volume_look_old])
     def reaper_should_delete_volume(self):
@@ -103,4 +104,3 @@ class ReaperShouldKillOlderUnattachedVolumes(InstanceTest):
         time_out = FLAGS.reddwarf_volume_time_out + 30
         assert_raises(NotFound, self.dbaas.instances.get, self.id)
         #TODO: Make sure quotas aren't affected.
-

--- a/tests/integration/tests/scheduler/driver.py
+++ b/tests/integration/tests/scheduler/driver.py
@@ -54,6 +54,7 @@ flavor_href = None
 initial_instance = None
 original_notification_count = None
 
+
 def out_of_instance_memory_nofication_count():
     """Counts the times an OutOfInstanceMemory notification has been raised."""
     return count_notifications(notifier.ERROR, "out.of.instance.memory")
@@ -74,7 +75,7 @@ def setUp():
     original_notification_count = out_of_instance_memory_nofication_count()
 
 
-@test(groups=[GROUP, GROUP+".create"], depends_on=[setUp])
+@test(groups=[GROUP, GROUP + ".create"], depends_on=[setUp])
 def create_instance():
     """Create the instance. Expect the scheduler to fail the request."""
     #TODO(tim.simpson): Try to get this to work using a direct instance
@@ -89,7 +90,7 @@ def create_instance():
     initial_instance = client.instances.create(
         "sch_test_" + str(now),
         flavor_href,
-        {"size":1},
+        {"size": 1},
         [{"name": "firstdb", "charset": "latin2",
           "collate": "latin2_general_ci"}])
 
@@ -104,8 +105,8 @@ def confirm_instance_is_dead(self):
 def find_evidence_scheduler_failed_in_logs():
     """Eavesdrop on the logs until we see the scheduler failed, or time-out."""
     evidence = "Error scheduling " + initial_instance.name
-    poll_until(lambda : file(FLAGS.logfile, 'r').read(),
-               lambda log : evidence in log, sleep_time=3, time_out=60)
+    poll_until(lambda: file(FLAGS.logfile, 'r').read(),
+               lambda log: evidence in log, sleep_time=3, time_out=60)
 
 
 @test(groups=[GROUP], depends_on=[find_evidence_scheduler_failed_in_logs])
@@ -115,7 +116,7 @@ class AfterSchedulingHasFailed(unittest.TestCase):
         current_count = out_of_instance_memory_nofication_count()
         # Additional ops notifications should have been added.
         poll_until(out_of_instance_memory_nofication_count,
-                   lambda count : original_notification_count < count,
+                   lambda count: original_notification_count < count,
                    sleep_time=1, time_out=60)
 
     def test_confirm_instance_is_in_error_state(self):
@@ -124,14 +125,14 @@ class AfterSchedulingHasFailed(unittest.TestCase):
         assert_equal("ERROR", instance.status)
 
 
-@test(groups=[GROUP, GROUP + ".end"], depends_on_groups=[GROUP+".create"])
+@test(groups=[GROUP, GROUP + ".end"], depends_on_groups=[GROUP + ".create"])
 @time_out(30)
 def destroy_instance():
     """Delete the instance we tried to create for this test."""
     client.instances.delete(initial_instance)
     id = initial_instance.id
     try:
-        lc = LoopingCall(f=lambda : client.instances.get(id)).start(2, True)
+        lc = LoopingCall(f=lambda: client.instances.get(id)).start(2, True)
         lc.wait()
         self.fail("Expected exception.NotFound.")
     except exceptions.NotFound:

--- a/tests/integration/tests/util/__init__.py
+++ b/tests/integration/tests/util/__init__.py
@@ -57,7 +57,7 @@ WHITE_BOX = test_config.white_box
 if WHITE_BOX:
     from nova import flags
     from nova import utils
-    from reddwarf import dns # import for flag values
+    from reddwarf import dns  # import for flag values
     from reddwarf.notifier import logfile_notifier  # Here so flags are loaded
     from reddwarf import exception
     FLAGS = flags.FLAGS
@@ -81,6 +81,7 @@ def assert_mysql_failure_msg_was_permissions_issue_is_passed():
     assert_mysql_failure_msg_was_permissions_issue(
         """(1045, "Access denied for user 'anous*&^er'@'10.0.2.15'""")
 
+
 @test(groups="unit")
 def assert_mysql_failure_msg_was_permissions_issue_is_failed():
     assert_raises(ASSERTION_ERROR,
@@ -98,6 +99,8 @@ def assert_mysql_connection_fails(user_name, password, ip):
 
 
 _dns_entry_factory = None
+
+
 def get_dns_entry_factory():
     """Returns a DNS entry factory."""
     global _dns_entry_factory
@@ -105,6 +108,7 @@ def get_dns_entry_factory():
         class_name = FLAGS.dns_instance_entry_factory
         _dns_entry_factory = utils.import_object(class_name)
     return _dns_entry_factory
+
 
 def check_database(instance_id, dbname):
     """Checks if the name appears in an instance's list of databases."""
@@ -193,6 +197,7 @@ def find_mysql_procid_on_instance(local_id):
     except ValueError:
         return None
 
+
 def init_engine(user, password, host):
     return create_engine("mysql://%s:%s@%s:3306" %
                                (user, password, host),
@@ -226,6 +231,7 @@ def wait_for_compute_service():
     except exception.PollTimeOut:
         raise RuntimeError("Could not find the line %s in the logs." % line)
 
+
 def should_run_rsdns_tests():
     """If true, then the RS DNS tests should also be run."""
     return FLAGS.dns_driver == "reddwarf.dns.rsdns.driver.RsDnsDriver"
@@ -233,7 +239,7 @@ def should_run_rsdns_tests():
 
 def string_in_list(str, substr_list):
     """Returns True if the string appears in the list."""
-    return any([str.find(x) >=0 for x in substr_list])
+    return any([str.find(x) >= 0 for x in substr_list])
 
 
 def get_vz_ip_for_device(instance_id, device):

--- a/tests/integration/tests/util/check.py
+++ b/tests/integration/tests/util/check.py
@@ -23,8 +23,6 @@ from proboscis.asserts import assert_not_equal
 from proboscis.asserts import assert_true
 
 
-
-
 def get_stack_trace_of_caller(level_up):
     """Gets the stack trace at the point of the caller."""
     level_up += 1
@@ -34,6 +32,7 @@ def get_stack_trace_of_caller(level_up):
         caller_index = 0
     new_st = st[0:caller_index]
     return new_st
+
 
 def raise_blame_caller(level_up, ex):
     """Raises an exception, changing the stack trace to point to the caller."""

--- a/tests/integration/tests/util/client.py
+++ b/tests/integration/tests/util/client.py
@@ -39,6 +39,7 @@ CALLED_MONKEY_PATCH = False
 def add_report_event_to(home, name):
     """Takes a module, class, etc, and an attribute name to decorate."""
     func = getattr(home, name)
+
     def __cb(*args, **kwargs):
         # While %s turns a var into a string but in some rare cases explicit
         # str() is less likely to raise an exception.
@@ -77,7 +78,6 @@ class TestClient(object):
     def __init__(self, real_client):
         """Accepts a normal client."""
         self.real_client = real_client
-
 
     @staticmethod
     def find_flavor_self_href(flavor):

--- a/tests/integration/tests/util/instance.py
+++ b/tests/integration/tests/util/instance.py
@@ -54,13 +54,13 @@ class InstanceTest(object):
         self.db = utils.import_object(FLAGS.db_driver)
         self.user = None  # The user instance who owns the instance.
         self.dbaas = None  # The rich client instance used by these tests.
-        self.dbaas_flavor = None # The flavor object of the instance.
+        self.dbaas_flavor = None  # The flavor object of the instance.
         self.dbaas_flavor_href = None  # The flavor of the instance.
         self.id = None  # The ID of the instance in the database.
         self.local_id = None  # The local ID of the instance in the database.
         self.name = None  # Test name, generated each test run.
-        self.volume = {'size': volume_size} # The volume the instance will have.
-        self.initial_result = None # The initial result from the create call.
+        self.volume = {'size': volume_size}  # The volume the instance will ha
+        self.initial_result = None  # The initial result from the create call.
         self.volume_id = None  # Set by _get_instance_volume.
 
     def init(self, name_prefix, user_requirements=None):
@@ -103,7 +103,7 @@ class InstanceTest(object):
             assert_equal(result[1].status, dbaas_mapping[power_state.FAILED])
             return True
 
-    def _assert_volume_is_eventually_deleted(self, time_out=3*60):
+    def _assert_volume_is_eventually_deleted(self, time_out=(3 * 60)):
         """Polls until some time_out to see if the volume is deleted.
 
         This test is according to the database, not the REST API.
@@ -180,8 +180,9 @@ class InstanceTest(object):
 
     def _check_vifs_cleaned(self):
         for network_id in [1, 2]:
+            admin_context = context.get_admin_context()
             vif = self.db.virtual_interface_get_by_instance_and_network(
-                                                    context.get_admin_context(),
+                                                    admin_context,
                                                     self.id,
                                                     network_id)
             assert_equal(vif, None)
@@ -199,12 +200,13 @@ class InstanceTest(object):
     def wait_for_compute_instance_to_suspend(self):
         """Polls until the compute instance is known to be suspended."""
         poll_until(self._get_compute_instance_state,
-                         lambda state : state in VALID_ABORT_STATES,
+                         lambda state: state in VALID_ABORT_STATES,
                          sleep_time=1,
                          time_out=FLAGS.reddwarf_instance_suspend_time_out)
 
     def _check_volume_detached(self):
-        result = self.db.volume_get(context.get_admin_context(), self.volume_id)
+        result = self.db.volume_get(context.get_admin_context(),
+                                    self.volume_id)
         if result['attach_status'] == "detached" and \
            result['status'] == "available":
             return True

--- a/tests/integration/tests/util/report.py
+++ b/tests/integration/tests/util/report.py
@@ -43,6 +43,7 @@ class Reporter(object):
 
     def _update_instance(self, id):
         root = "%s/%s" % (self.root_path, id)
+
         def save_file(path, short_name):
             if USE_LOCAL_OVZ:
                 try:
@@ -73,6 +74,7 @@ REPORTER = Reporter(test_config.values["report_directory"])
 
 def log(msg):
     REPORTER.log(msg)
+
 
 def update():
     REPORTER.update()

--- a/tests/integration/tests/util/services.py
+++ b/tests/integration/tests/util/services.py
@@ -40,7 +40,6 @@ def _is_web_service_alive(url):
 _running_services = []
 
 
-
 def get_running_services():
     """ Returns the list of services which this program has started."""
     return _running_services
@@ -98,9 +97,11 @@ class Service(object):
         if not self.cmd:
             return False
         # The cmd[1] signifies the executable python script. It gets invoked
-        # as python /path/to/executable args, so the entry is /path/to/executable
+        # as python /path/to/executable args, so the entry is
+        # /path/to/executable
         actual_command = self.cmd[1].split("/")[-1]
-        proc = start_proc(["/usr/bin/pgrep", "-f", actual_command], shell=False)
+        proc_command = ["/usr/bin/pgrep", "-f", actual_command]
+        proc = start_proc(proc_command, shell=False)
         # this is to make sure there is only one pid returned from the pgrep
         has_two_lines = False
         pid = None
@@ -148,11 +149,13 @@ class Service(object):
             return False
         time.sleep(1)
         # The cmd[1] signifies the executable python script. It gets invoked
-        # as python /path/to/executable args, so the entry is /path/to/executable
+        # as python /path/to/executable args, so the entry is
+        # /path/to/executable
         actual_command = self.cmd[1].split("/")[-1]
         print actual_command
-        print ["/usr/bin/pgrep", "-f", actual_command]
-        proc = start_proc(["/usr/bin/pgrep", "-f", actual_command], shell=False)
+        proc_command = ["/usr/bin/pgrep", "-f", actual_command]
+        print proc_command
+        proc = start_proc(proc_command, shell=False)
         line = proc.stdout.readline()
         print line
         # pgrep only returns a pid. if there is no pid, it'll return nothing

--- a/tests/integration/tests/util/test_config.py
+++ b/tests/integration/tests/util/test_config.py
@@ -67,9 +67,11 @@ def glance_code_root():
     """The file path to the Glance source code."""
     return str(values.get("glance_code_root"))
 
+
 def glance_bin_root():
     """The file path to the Glance bin directory."""
     return str(values.get("glance_code_root")) + "/bin/"
+
 
 def glance_images_directory():
     """The path to images that will be uploaded by Glance."""
@@ -80,9 +82,11 @@ def nova_code_root():
     """The path to the Nova source code."""
     return str(values.get("nova_code_root"))
 
+
 def keystone_code_root():
     """The path to the Keystone source code."""
     return str(values.get("keystone_code_root"))
+
 
 def keystone_bin(service):
     """The path of the specific keystone service"""
@@ -109,33 +113,36 @@ def python_cmd_list():
 def _setup():
     """Initializes the module."""
     from tests.util.users import Users
-    global nova_auth_url
-    global reddwarf_auth_url
+    global clean_slate
     global compute_service
     global dbaas
-    global nova
-    global users
     global dbaas_image
-    global typical_nova_image_name
-    global use_venv
-    global values
     global dbaas_url
+    global glance_image
+    global keystone_service
+    global nova
+    global nova_auth_url
+    global reddwarf_auth_url
+    global test_mgmt
+    global typical_nova_image_name
+    global use_reaper
+    global use_venv
+    global users
+    global values
     global version_url
     global volume_service
-    global keystone_service
-    global glance_image
-    global use_reaper
-    global clean_slate
     global white_box
-    global test_mgmt
     clean_slate = os.environ.get("CLEAN_SLATE", "False") == "True"
     values = load_configuration()
     if os.environ.get("FAKE_MODE", "False") == "True":
         values["fake_mode"] = True
     use_venv = values.get("use_venv", True)
-    nova_auth_url = str(values.get("nova_auth_url", "http://localhost:5000/v2.0"))
-    reddwarf_auth_url = str(values.get("reddwarf_auth_url", "http://localhost:5000/v1.1"))
-    dbaas_url = str(values.get("dbaas_url", "http://localhost:8775/v1.0/dbaas"))
+    nova_auth_url = str(values.get("nova_auth_url",
+                                   "http://localhost:5000/v2.0"))
+    reddwarf_auth_url = str(values.get("reddwarf_auth_url",
+                                       "http://localhost:5000/v1.1"))
+    dbaas_url = str(values.get("dbaas_url",
+                               "http://localhost:8775/v1.0/dbaas"))
     version_url = str(values.get("version_url", "http://localhost:8775/"))
     nova_url = str(values.get("nova_url", "http://localhost:8774/v1.1"))
     nova_code_root = str(values["nova_code_root"])
@@ -164,10 +171,10 @@ def _setup():
                       url=nova_url)
     volume_service = Service(cmd=python_cmd_list() +
                              ["%s/bin/nova-volume" % nova_code_root,
-                              "--flagfile=%s" % nova_conf ])
+                              "--flagfile=%s" % nova_conf])
     compute_service = Service(cmd=python_cmd_list() +
                               ["%s/bin/nova-compute" % nova_code_root,
-                               "--flagfile=%s" % nova_conf ])
+                               "--flagfile=%s" % nova_conf])
     keystone_service = Service(python_cmd_list() +
                                [keystone_bin("keystone-auth"),
                                 "-c %s" % keystone_conf])

--- a/tests/integration/tests/util/topics.py
+++ b/tests/integration/tests/util/topics.py
@@ -25,7 +25,8 @@ WHITE_BOX = test_config.white_box
 if WHITE_BOX:
     from nova import flags
     from nova import utils
-    from nova.scheduler import manager  # Do this to create flag "scheduler_driver"
+    # importing nova.scheduler.manager creates the flag "scheduler_driver"
+    from nova.scheduler import manager
     FLAGS = flags.FLAGS
 
 

--- a/tests/integration/tests/util/users.py
+++ b/tests/integration/tests/util/users.py
@@ -85,7 +85,7 @@ class Users(object):
 
     def find_user_by_name(self, name):
         """Finds a user who meets the requirements and has been used least."""
-        users = (user for user in self.users if user.auth_user==name)
+        users = (user for user in self.users if user.auth_user == name)
         user = min(users, key=lambda user: user.test_count)
         user.test_count += 1
         return user

--- a/tests/integration/tests/util/util_test.py
+++ b/tests/integration/tests/util/util_test.py
@@ -100,6 +100,3 @@ class TestUsers(unittest.TestCase):
         for user in normals:
             self.assertFalse(user.requirements.is_admin)
             self.assertEqual(expected_test_count, user.test_count)
-
-
-


### PR DESCRIPTION
Root enabled history tests are enabled and reworked to find the history in instance details--this can change.
A whole host of PEP8 compatibility changes, too.
