### PR TITLE
Resize flavor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,18 @@ Allows the services to continue running in the background
 
 ***
 
-#### Kick start the build/initialize/build-image/start commands
+#### Kick start the build/initialize/build-image commands
 *Add mysql as a parameter to set build and add the mysql guest image*
 
     $ ./redstack kick-start mysql
+
+#### Start up the reddwarf services in a screen session
+
+    $ ./redstack start
+
+ or, to run outside of a screen:
+
+    $ ./redstack run
 
 ***
 
@@ -95,10 +103,6 @@ Allows the services to continue running in the background
 #### Build the image and add it to glance
 
     $ ./redstack build-image mysql
-
-#### Start up the reddwarf services in a screen session
-
-    $ ./redstack start
 
 ***
 
@@ -122,6 +126,7 @@ Allows the services to continue running in the background
 
     $ RECLONE=yes ./redstack install
     $ ./redstack kick-start mysql
+    $ ./redstack start
 
  or
 

--- a/scripts/conf/test.conf
+++ b/scripts/conf/test.conf
@@ -25,8 +25,9 @@
     "reddwarf_conf":"/tmp/reddwarf.conf",
     "reddwarf_version":"v0.1",
     "reddwarf_max_accepted_volume_size":128,
-    "reddwarf_must_have_volume":true,
+    "reddwarf_must_have_volume":false,
     "reddwarf_can_have_volume":true,
+    "reddwarf_main_instance_has_volume": false,
     "use_reaper":false,
     "users": [
         { "auth_user":"radmin",

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -12,7 +12,7 @@
 REDSTACK_SCRIPTS=${REDSTACK_SCRIPTS:-`pwd`}
 REDSTACK_TESTS=$REDSTACK_SCRIPTS/../tests/
 
-USERHOME="/home/"`whoami`
+USERHOME=$HOME
 
 # Load options not checked into VCS.
 if [ -f $REDSTACK_SCRIPTS/options.rc ]; then
@@ -355,7 +355,7 @@ function run_devstack() {
     cd $PATH_DEVSTACK_SRC
 
     # Creating this lock directory seems sure-fire.
-    mkdir -p /home/$USERNAME/nova_locks
+    mkdir -p $USERHOME/nova_locks
 
     echo "
 # Set some arguments for devstack.
@@ -368,7 +368,7 @@ SERVICE_PASSWORD=$SERVICE_PASSWORD
 # The lock_path is by default /opt/stack/nova; if this path is a shared
 # folder in VirtualBox things seem to break. We fix it by setting EXTRA_OPS
 # to force lock_path to /tmp.
-EXTRA_OPTS=(lock_path=/home/$USERNAME/nova_locks)
+EXTRA_OPTS=(lock_path=$USERHOME/nova_locks)
 " > localrc
     if [ -n "$USING_VAGRANT" ]
     then
@@ -659,16 +659,15 @@ function cmd_build_image() {
 
 
     USERNAME=`whoami`
-    HOMEDIR=`getent passwd $USERNAME | cut -d: -f6`
-    mkdir -p /home/$USERNAME/images
-    VM_PATH=/home/$USERNAME/images/oneiric_${SERVICE_TYPE}_image
+    mkdir -p $USERHOME/images
+    VM_PATH=$USERHOME/images/oneiric_${SERVICE_TYPE}_image
     UBUNTU_DISTRO=ubuntu_oneiric
     UBUNTU_DISTRO_NAME=oneiric
 
     # If the path doesnt exist, build it, otherwise just upload it
     if [ ! -d $VM_PATH ]
     then
-        build_vm $HOMEDIR $USERNAME $UBUNTU_DISTRO_NAME $VM_PATH $SERVICE_TYPE
+        build_vm $USERHOME $USERNAME $UBUNTU_DISTRO_NAME $VM_PATH $SERVICE_TYPE
     else
         exclaim "Found image in $VM_PATH using the qcow2 image found here..."
     fi
@@ -953,7 +952,6 @@ function cmd_kick_start() {
     cmd_build
     cmd_initialize
     cmd_build_image $1
-    #cmd_start
 }
 
 function cmd_reset_task() {
@@ -1078,4 +1076,5 @@ function run_command() {
 }
 
 run_command $@
+
 

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -279,7 +279,6 @@ function install_packages_2() {
     echo "
 logdir=$REDSTACK_SCRIPTS/../report/logs/
 logfile_mode=660
-##lock_path=/tmp
 " >> /etc/nova/nova.conf
 
 
@@ -355,6 +354,9 @@ function run_devstack() {
     exclaim "Running devstack..."
     cd $PATH_DEVSTACK_SRC
 
+    # Creating this lock directory seems sure-fire.
+    mkdir -p /home/$USERNAME/nova_locks
+
     echo "
 # Set some arguments for devstack.
 # These passwords originally come from redstack.rc.
@@ -366,7 +368,7 @@ SERVICE_PASSWORD=$SERVICE_PASSWORD
 # The lock_path is by default /opt/stack/nova; if this path is a shared
 # folder in VirtualBox things seem to break. We fix it by setting EXTRA_OPS
 # to force lock_path to /tmp.
-EXTRA_OPTS=(lock_path=/tmp)
+EXTRA_OPTS=(lock_path=/home/$USERNAME/nova_locks)
 " > localrc
     if [ -n "$USING_VAGRANT" ]
     then
@@ -751,7 +753,13 @@ function cmd_initialize() {
 
     exclaim "Initializing the Reddwarf Database..."
     rd_manage db_sync repo_path=/opt/stack/reddwarf_lite/reddwarf_test.sqlite
+
+    # Incredibly useful for testing resize in a VM.
+    set +e
+    mysql_nova "INSERT INTO instance_types (name, id, memory_mb, vcpus, deleted, ephemeral_gb, rxtx_factor, flavorid, root_gb) VALUES('tinier', 6, 506, 1, 0, 40, 1, 6, 10);"
+    set -e
 }
+
 
 ###############################################################################
 # Start Reddwarf specific daemons interactively in a screen session
@@ -859,12 +867,12 @@ function cmd_nova_client() {
         nova --auth_url=http://localhost:35357/v2.0 \
             --tenant_name=reddwarf --username=radmin --password=radmin \
             --service_type=compute --region_name=RegionOne \
-            --service_name='Compute Service' --version=2 $@
+            --service_name='Compute Service' $@
     else
         nova --auth_url=http://localhost:35357/v2.0 \
             --tenant_name=reddwarf --username=radmin --password=radmin \
             --service_type=volume --region_name=RegionOne \
-            --service_name='Volume Service' --version=2 $@
+            --service_name='Volume Service' $@
     fi
 }
 
@@ -945,7 +953,11 @@ function cmd_kick_start() {
     cmd_build
     cmd_initialize
     cmd_build_image $1
-    cmd_start
+    #cmd_start
+}
+
+function cmd_reset_task() {
+    mysql_reddwarf "UPDATE instances SET task_id=1 WHERE id='$1'"
 }
 
 function cmd_update_projects() {
@@ -1020,6 +1032,7 @@ function print_usage() {
           run             - Starts RD but not in a screen.
           run-fake        - Runs the server in fake mode.
           update-projects - Git pull on all the daemons reddwarf dependencies.
+          reset-task      - Sets an instance task to NONE.
     "
     exit 1
 }
@@ -1057,6 +1070,7 @@ function run_command() {
         "kick-start" ) shift; cmd_kick_start $@;;
         "run-fake" ) shift; cmd_run_fake $@;;
         "update-projects" ) cmd_update_projects;;
+        "reset-task" ) shift; cmd_reset_task $@;;
         * )
             echo "'$1' not a valid command"
             exit 1

--- a/tests/integration/int_tests.py
+++ b/tests/integration/int_tests.py
@@ -198,6 +198,7 @@ if __name__ == '__main__':
             "services.initialize",
             "dbaas.guest.initialize",  # instances.GROUP_START,
             "dbaas.preinstance",
+            "dbaas.api.instances.actions.resize.instance",
             "dbaas.api.instances.actions.restart",
             "dbaas.guest.shutdown",
             versions.GROUP,

--- a/tests/integration/tests/api/instances_actions.py
+++ b/tests/integration/tests/api/instances_actions.py
@@ -132,10 +132,7 @@ class ActionTestBase(object):
         self.dbaas.users.create(instance_info.id, users)
         def has_user():
             users = self.dbaas.users.list(instance_info.id)
-            for user in users:
-                if user.name == MYSQL_USERNAME:
-                    return True
-            return
+            return any([user.name == MYSQL_USERNAME for user in users])
         poll_until(has_user, time_out = 30)
         if not FAKE_MODE:
             time.sleep(5)


### PR DESCRIPTION
- Added a "reset_task" command, which changes an instances task back to nothing in case it gets stuck.
- Added the resize flavor test group.
- Resize flavor was inheriting from the RebootTestBase class, so I made a smaller super class for it to inherit from.
- Added a work around for a weird bug where MySQL users get deleted during a resize. This way the test can acknowledge it and still work around it.
