### PR TITLE
tests updated to reflect root_enabled_history move to new mgmt api & client

### DIFF
--- a/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.json
@@ -63,8 +63,6 @@ Date: Wed, 25 Jan 2012 21:58:25 GMT
         "hostname": "e09ad9a3f73309469cf1f43d11e79549caf9acf2.rackspaceclouddb.com", 
         "id": "692d8418-7a8f-47f1-8060-59846c6e024f", 
         "name": "xml_rack_instance", 
-        "root_enabled_at": "2012-01-25 21:58:11", 
-        "root_enabled_by": "examples", 
         "server_state_description": "active", 
         "status": "ACTIVE", 
         "updated": "2012-01-25T21:55:30Z", 

--- a/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-instance-details-response.xml
@@ -3,7 +3,7 @@ Content-Type: application/xml
 Content-Length: 1687
 Date: Wed, 25 Jan 2012 21:58:26 GMT
 
-<instance account_id="examples" created="2012-01-25T21:53:18Z" host="host" hostname="e09ad9a3f73309469cf1f43d11e79549caf9acf2.rackspaceclouddb.com" id="692d8418-7a8f-47f1-8060-59846c6e024f" name="xml_rack_instance" root_enabled_at="2012-01-25 21:58:11" root_enabled_by="examples" server_state_description="active" status="ACTIVE" updated="2012-01-25T21:55:30Z" xmlns="http://docs.openstack.org/database/api/v1.0">
+<instance account_id="examples" created="2012-01-25T21:53:18Z" host="host" hostname="e09ad9a3f73309469cf1f43d11e79549caf9acf2.rackspaceclouddb.com" id="692d8418-7a8f-47f1-8060-59846c6e024f" name="xml_rack_instance" server_state_description="active" status="ACTIVE" updated="2012-01-25T21:55:30Z" xmlns="http://docs.openstack.org/database/api/v1.0">
 	<volume description="Volume ID: None assigned to Instance: None" id="2" name="xml_rack_instance" size="2"/>
 	<guest_status created_at="2012-01-25 21:53:23" deleted="False" deleted_at="None" instance_id="2" state="1" state_description="running" updated_at="2012-01-25 21:57:57"/>
 	<users>

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-response.json
@@ -4,9 +4,9 @@ Content-Length: 108
 Date: Wed, 25 Jan 2012 21:58:26 GMT
 
 {
-    "root_enabled_history": {
-        "id": 2, 
-        "root_enabled_at": "2012-01-25 21:58:11", 
-        "root_enabled_by": "examples"
+    "root_history": {
+        "id": 692d8418-7a8f-47f1-8060-59846c6e024f, 
+        "enabled": "2012-01-25 21:58:11", 
+        "user": "examples"
     }
 }

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-response.json
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-response.json
@@ -6,7 +6,7 @@ Date: Wed, 25 Jan 2012 21:58:26 GMT
 {
     "root_history": {
         "id": 692d8418-7a8f-47f1-8060-59846c6e024f, 
-        "enabled": "2012-01-25 21:58:11", 
+        "enabled": "2012-01-25T21:58:11", 
         "user": "examples"
     }
 }

--- a/apidocs/src/resources/samples/db-mgmt-get-root-details-response.xml
+++ b/apidocs/src/resources/samples/db-mgmt-get-root-details-response.xml
@@ -3,5 +3,5 @@ Content-Type: application/xml
 Content-Length: 148
 Date: Wed, 25 Jan 2012 21:58:27 GMT
 
-<root_enabled_history id="2" root_enabled_at="2012-01-25 21:58:11" root_enabled_by="examples" xmlns="http://docs.openstack.org/database/api/v1.0"/>
+<root_history id="692d8418-7a8f-47f1-8060-59846c6e024f" enabled="2012-01-25T21:58:11" user="examples" xmlns="http://docs.openstack.org/database/api/v1.0"/>
 

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -753,6 +753,13 @@ function cmd_rd_client() {
     reddwarf-cli $@
 }
 
+function cmd_rd_mgmt_client() {
+    # This serves as an example of how to call the Reddwarf managment client script.
+    reddwarf-cli auth login radmin radmin reddwarf \
+        http://localhost:35357/v2.0
+    reddwarf-mgmt-cli $@
+}
+
 function cmd_delete_nova_instance() {
     # Nova will not let you delete an instance whose state is error, but we
     # won't let that stop us.
@@ -882,6 +889,7 @@ function print_usage() {
           glance-client   - Runs glance client with admin user.
           nova-client     - Runs Nova client with admin user.
           rd-client       - Runs Reddwarf client with admin user.
+          rd-mgmt-client  - Runs Reddwarf management client with admin user.
                             * Shows a valid token.
           wipe-logs       - Resets all log files.
           nova-delete     - Deletes a nova instance.
@@ -917,6 +925,7 @@ function run_command() {
         "glance-client" ) shift; cmd_glance_client;;
         "nova-client" ) shift; cmd_nova_client $@;;
         "rd-client" ) shift; cmd_rd_client $@;;
+        "rd-mgmt-client" ) shift; cmd_rd_mgmt_client $@;;
         "nova-delete" ) shift; cmd_delete_nova_instance $@;;
         "wipe-logs" ) cmd_wipe_logs;;
         "rd-sql" ) shift; cmd_rd_sql $@;;

--- a/tests/integration/tests/api/instances.py
+++ b/tests/integration/tests/api/instances.py
@@ -364,7 +364,6 @@ def assert_unprocessable(func, *args):
         pass  # Good
 
 
-
 @test(depends_on_classes=[CreateInstance],
       groups=[GROUP, GROUP_START, 'dbaas.mgmt.hosts_post_install'],
       enabled=create_new_instance())

--- a/tests/integration/tests/api/instances_actions.py
+++ b/tests/integration/tests/api/instances_actions.py
@@ -327,7 +327,7 @@ class RebootTests(RebootTestBase):
 @test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP,
               GROUP + ".resize.instance"],
       depends_on_groups=[GROUP_START], depends_on=[create_user],
-      runs_after=[RebootTests], enabled=False)
+      runs_after=[RebootTests])
 class ResizeInstanceTest(ActionTestBase):
 
     """

--- a/tests/integration/tests/api/instances_actions.py
+++ b/tests/integration/tests/api/instances_actions.py
@@ -130,10 +130,12 @@ class ActionTestBase(object):
         users = [{"name": MYSQL_USERNAME, "password": MYSQL_PASSWORD,
                   "database": MYSQL_USERNAME}]
         self.dbaas.users.create(instance_info.id, users)
+
         def has_user():
             users = self.dbaas.users.list(instance_info.id)
             return any([user.name == MYSQL_USERNAME for user in users])
-        poll_until(has_user, time_out = 30)
+
+        poll_until(has_user, time_out=30)
         if not FAKE_MODE:
             time.sleep(5)
 
@@ -325,7 +327,7 @@ class RebootTests(RebootTestBase):
 @test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP,
               GROUP + ".resize.instance"],
       depends_on_groups=[GROUP_START], depends_on=[create_user],
-      runs_after=[RebootTests])
+      runs_after=[RebootTests], enabled=False)
 class ResizeInstanceTest(ActionTestBase):
 
     """
@@ -410,7 +412,8 @@ class ResizeInstanceTest(ActionTestBase):
         assert_equal(str(self.instance.flavor['id']), "1")
 
 
-@test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP, GROUP + ".resize.instance"],
+@test(groups=[tests.INSTANCES, INSTANCE_GROUP, GROUP,
+              GROUP + ".resize.instance"],
       depends_on_groups=[GROUP_START], depends_on=[create_user],
       runs_after=[RebootTests, ResizeInstanceTest])
 def resize_should_not_delete_users():

--- a/tests/integration/tests/api/root.py
+++ b/tests/integration/tests/api/root.py
@@ -57,22 +57,17 @@ class TestRoot(object):
         self.dbaas_admin = util.create_dbaas_client(instance_info.admin_user)
 
     def _verify_root_timestamp(self, id):
-        mgmt_instance = self.dbaas.instances.get(id)
-        assert_true(mgmt_instance is not None)
-        timestamp = mgmt_instance.root_enabled_at
+        reh = self.dbaas_admin.management.root_enabled_history(id)
+        timestamp = reh.enabled
         assert_equal(self.root_enabled_timestamp, timestamp)
-        if test_config.values['test_mgmt']:
-            reh = self.dbaas_admin.management.root_enabled_history(id)
-            timestamp = reh.root_enabled_at
-            assert_equal(self.root_enabled_timestamp, timestamp)
-            assert_equal(id, reh.id)
+        assert_equal(id, reh.id)
 
     def _root(self):
         global root_password
         host = "%"
         user, password = self.dbaas.root.create(instance_info.id)
-        instance = self.dbaas.instances.get(instance_info.id)
-        self.root_enabled_timestamp = instance.root_enabled_at
+        reh = self.dbaas_admin.management.root_enabled_history
+        self.root_enabled_timestamp = reh(instance_info.id).enabled
 
     def _root_local_sql(self):
         engine = init_engine(user, password, instance_info.user_ip)
@@ -85,8 +80,8 @@ class TestRoot(object):
                 assert_equal(user, row['User'])
                 assert_equal(host, row['Host'])
         root_password = password
-        instance = self.dbaas.instances.get(instance_info.id)
-        self.root_enabled_timestamp = instance.root_enabled_at
+        reh = self.dbaas_admin.management.root_enabled_history
+        self.root_enabled_timestamp = reh(instance_info.id).enabled
         assert_not_equal(self.root_enabled_timestamp, 'Never')
 
     @test


### PR DESCRIPTION
root history is no longer an appendage attached to instance details
furthermore it's just root_history and not root_enabled_history in the API
