### PR TITLE
Tried to make resize flavor tests easier to run.

### DIFF
--- a/scripts/conf/test.conf
+++ b/scripts/conf/test.conf
@@ -19,6 +19,7 @@
     "glance_images_directory": "/glance_images",
     "glance_image": "debian-squeeze-x86_64-openvz.tar.gz",
     "instance_flavor_name":"m1.rd-tiny",
+    "instance_bigger_flavor_name":"m1.rd-smaller",
     "nova_url":"http://localhost:8774/v1.1",
     "nova_service_type":"compute",
     "report_directory":"/integration/report",

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -251,14 +251,8 @@ function install_reddwarf_packages() {
 
     exclaim "Installing Proboscis."
     sudo pip install openstack.nose_plugin
-    #sudo pip install proboscis
+    sudo pip install proboscis
 
-    sudo rm -rf /opt/stack/python-proboscis
-    cd /opt/stack
-    git_clone https://github.com/TimSimpsonR/python-proboscis.git \
-        /opt/stack/python-proboscis runs_after_dangerous
-    cd /opt/stack/python-proboscis
-    sudo python setup.py develop
     cd /tmp
 
     echo "Adding to nova.conf..."
@@ -615,7 +609,9 @@ function cmd_initialize() {
     set +e
     mysql_nova "INSERT INTO instance_types (name, id, memory_mb, vcpus, deleted, ephemeral_gb, rxtx_factor, flavorid, root_gb) VALUES('tinier', 6, 506, 1, 0, 40, 1, 6, 10);"
     # It can also be useful to have a flavor with 512 megs and a bit of disk space.
-    mysql_nova "INSERT INTO instance_types (name, id, memory_mb, vcpus, deleted, ephemeral_gb, rxtx_factor, flavorid, root_gb) VALUES('m1.rd-tiny', 7, 512, 1, 0, 40, 1, 6, 2);"
+    mysql_nova "INSERT INTO instance_types (name, id, memory_mb, vcpus, deleted, ephemeral_gb, rxtx_factor, flavorid, root_gb) VALUES('m1.rd-tiny', 7, 512, 1, 0, 40, 1, 7, 2);"
+    # Its also useful to have a slightly bigger flavor...
+    mysql_nova "INSERT INTO instance_types (name, id, memory_mb, vcpus, deleted, ephemeral_gb, rxtx_factor, flavorid, root_gb) VALUES('m1.rd-smaller', 8, 768, 1, 0, 40, 1, 8, 2);"
     set -e
 }
 

--- a/tests/integration/tests/api/instances.py
+++ b/tests/integration/tests/api/instances.py
@@ -257,8 +257,8 @@ class CreateInstance(unittest.TestCase):
             assert_raises(nova_exceptions.OverLimit, dbaas.instances.create,
                           "way_too_large", instance_info.dbaas_flavor_href,
                           {'size': too_big + 1}, [])
-        else:
-            raise SkipTest("N/A: No max accepted volume size defined.")
+        #else:
+        #    raise SkipTest("N/A: No max accepted volume size defined.")
 
     def test_create(self):
         databases = []
@@ -624,11 +624,9 @@ class TestInstanceListing(object):
             check.links(instance_dict['links'])
             check.volume()
 
-    @test
+    @test(enabled=not test_config.values['hostname_not_implemented']
+                  and test_config.values['reddwarf_dns_support'])
     def test_instance_hostname(self):
-        dns_support = test_config.values['reddwarf_dns_support']
-        if not dns_support:
-            raise SkipTest("No dns support enabled for reddwarf.")
         instance = dbaas.instances.get(instance_info.id)
         hostname_prefix = ("%s" % (hashlib.sha1(instance.id).hexdigest()))
         instance_hostname_prefix = instance.hostname.split('.')[0]


### PR DESCRIPTION
- Added another flavor, this one with 768, we can use with the resize flavor test.
- Took out some code that raised SkipTest if something in the test config was turned off. Not sure why this wasn't caught, but this code (by nature of Proboscis) skips all other tests if set.
- Changed the resize flavor test code to use flavors from the config file (before it had literal flavor ids in the test code).
