### PR TITLE
No longer use ip grabbed by OVZ specific test code.

### DIFF
--- a/tests/integration/tests/api/users.py
+++ b/tests/integration/tests/api/users.py
@@ -127,7 +127,7 @@ class TestUsers(object):
 
     def show_databases(self, user, password):
         cmd = "sudo mysql -h %s -u '%s' -p'%s' -e 'show databases;'"\
-                % (instance_info.user_ip, user, password)
+                % (instance_info.get_address(), user, password)
         print("Running cmd: %s" % cmd)
         dblist, err = process(cmd)
         print("returned: %s" % dblist)
@@ -194,7 +194,7 @@ class TestUsers(object):
     def _check_connection(self, username, password):
         if not FAKE:
             util.assert_mysql_connection_fails(username, password,
-                                               instance_info.user_ip)
+                                               instance_info.get_address())
         # Also determine the db is gone via API.
         result = self.dbaas.users.list(instance_info.id)
         for item in result:

--- a/tests/integration/tests/openvz/dbaas_ovz.py
+++ b/tests/integration/tests/openvz/dbaas_ovz.py
@@ -89,7 +89,7 @@ class TestMultiNic(object):
             assert_equal(vz_ip, fixed_ip[0]['address'])
 
 
-@test(depends_on_classes=[TestMultiNic],
+@test(depends_on_groups=[GROUP_START], runs_after=[TestMultiNic],
       groups=[GROUP_TEST, "dbaas.guest.mysql"],
       enabled=not test_config.values['fake_mode'])
 class TestMysqlAccess(object):
@@ -102,13 +102,13 @@ class TestMysqlAccess(object):
     def test_mysql_admin(self):
         """Ensure we aren't allowed access with os_admin and wrong password."""
         assert_mysql_connection_fails("os_admin", "asdfd-asdf234",
-                                      instance_info.user_ip)
+                                      instance_info.get_address())
 
     @test
     def test_mysql_root(self):
         """Ensure we aren't allowed access with root and wrong password."""
         assert_mysql_connection_fails("root", "dsfgnear",
-                                      instance_info.user_ip)
+                                      instance_info.get_address())
 
     @test(enabled=WHITE_BOX)
     def test_zfirst_db(self):


### PR DESCRIPTION
- TestMyqlAccess now runs after but does not depend on the multi nic tests.
