### PR TITLE
Fixing a misconfiguration of the RestartTests.

### DIFF
--- a/tests/integration/tests/api/instances_actions.py
+++ b/tests/integration/tests/api/instances_actions.py
@@ -290,7 +290,8 @@ class RestartTests(RebootTestBase):
         # under test which aside from these tangential issues is working.
         self.unsuccessful_restart()
 
-    @after_class(always_run=True)
+    @test(depends_on=[test_set_up],
+          runs_after=[test_ensure_mysql_is_running,test_unsuccessful_restart])
     def test_successful_restart(self):
         """Restart MySQL via the REST API successfully."""
         self.successful_restart()


### PR DESCRIPTION
This one method was set to always run, which is why we keep seeing it anytime anything else fails. Changed config to avoid this.
