### PR TITLE
Making the configuration details more configurable with custom stuff.

### DIFF
--- a/scripts/conf/test_begin.conf
+++ b/scripts/conf/test_begin.conf
@@ -91,9 +91,7 @@
     "dbaas_image": 1,
     "dns_driver":"reddwarf.dns.rsdns.driver.RsDnsDriver",
     "dns_instance_entry_factory":"reddwarf.dns.rsdns.driver.RsDnsInstanceEntryFactory",
-    "hostname_not_implemented": true,
     "reddwarf_dns_support": false,
     "databases_page_size": 20,
     "instances_page_size": 20,
-    "users_page_size": 20
-}
+    "users_page_size": 20,

--- a/scripts/conf/test_end.conf
+++ b/scripts/conf/test_end.conf
@@ -1,0 +1,2 @@
+    "sentinel": null
+}

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -517,7 +517,7 @@ function cmd_set_image() {
     #TODO(hub-cap): Upload this sucker to our database.
     # This should be a reddwarf-manage function
     exclaim "Registering Glance image $GLANCE_IMAGEID with Reddwarf..."
-    
+
     rd_manage image_update $SERVICE_TYPE $GLANCE_IMAGEID
 }
 
@@ -580,6 +580,11 @@ function fix_rd_configfile() {
     cd $PATH_REDDWARF
     cp etc/reddwarf/reddwarf.conf.sample $USERHOME/reddwarf.conf
     cp etc/reddwarf/reddwarf-taskmanager.conf.sample $USERHOME/reddwarf-taskmanager.conf
+    EXTRA_CONF=$REDSTACK_SCRIPTS/conf/reddwarf.extra.conf
+    if [ -e $EXTRA_CONF ]; then
+        cat $EXTRA_CONF >> $USERHOME/reddwarf.conf
+        cat $EXTRA_CONF >> $USERHOME/reddwarf-taskmanager.conf
+    fi
     # Do some munging to get it a-working
     # Tenant is no longer needed from the config, but we are leaving it in
     # until we have a better example of stuff to sed out.
@@ -592,9 +597,13 @@ function rd_manage() {
 }
 
 function mod_test_conf() {
-
-    cp $REDSTACK_SCRIPTS/conf/test.conf $USERHOME
+    cp $REDSTACK_SCRIPTS/conf/test_begin.conf $USERHOME/test.conf
     sed -i "s/\/integration\/report/$ESCAPED_REDSTACK_SCRIPTS\/\.\.\/report/" $USERHOME/test.conf
+    EXTRA_CONF=$REDSTACK_SCRIPTS/conf/test.extra.conf
+    if [ -e $EXTRA_CONF ]; then
+        cat $EXTRA_CONF >> $USERHOME/test.conf
+    fi
+    cat $REDSTACK_SCRIPTS/conf/test_end.conf >> $USERHOME/test.conf
 }
 
 function cmd_initialize() {

--- a/tests/integration/tests/__init__.py
+++ b/tests/integration/tests/__init__.py
@@ -41,6 +41,8 @@ from tests.util.test_config import white_box as WHITE_BOX
 from tests.util.test_config import clean_slate as CLEAN_SLATE
 
 from tests.util.test_config import test_mgmt as TEST_MGMT
+from tests.util.test_config import fake_mode as FAKE_MODE
+
 
 
 # The following decorate a test only if we're doing white box testing.

--- a/tests/integration/tests/api/instances.py
+++ b/tests/integration/tests/api/instances.py
@@ -63,6 +63,7 @@ from tests.util import poll_until
 from tests.util.check import AttrCheck
 from tests import TEST_MGMT
 from tests import WHITE_BOX
+from tests import FAKE_MODE
 
 
 if WHITE_BOX:
@@ -619,8 +620,7 @@ class TestInstanceListing(object):
             check.links(instance_dict['links'])
             check.used_volume()
 
-    @test(enabled=not test_config.values['hostname_not_implemented']
-                  and test_config.values['reddwarf_dns_support'])
+    @test(enabled=not FAKE_MODE and test_config.values['reddwarf_dns_support'])
     def test_instance_hostname(self):
         instance = dbaas.instances.get(instance_info.id)
         hostname_prefix = ("%s" % (hashlib.sha1(instance.id).hexdigest()))

--- a/tests/integration/tests/util/__init__.py
+++ b/tests/integration/tests/util/__init__.py
@@ -280,8 +280,7 @@ def wait_for_compute_service():
 
 def should_run_rsdns_tests():
     """If true, then the RS DNS tests should also be run."""
-    dns_driver = test_config.values["reddwarf_dns_support"]
-    return dns_driver == "true"
+    return test_config.values.get("reddwarf_dns_support", False)
 
 
 def string_in_list(str, substr_list):

--- a/tests/integration/tests/util/test_config.py
+++ b/tests/integration/tests/util/test_config.py
@@ -26,6 +26,7 @@ __all__ = [
     "compute_service",
     "dbaas",
     "dbaas_image",
+    "fake_mode",
     "glance_code_root",
     "glance_image",
     "nova",
@@ -118,6 +119,7 @@ def _setup():
     global dbaas
     global dbaas_image
     global dbaas_url
+    global fake_mode
     global glance_image
     global keystone_service
     global nova
@@ -137,6 +139,7 @@ def _setup():
     values = load_configuration()
     if os.environ.get("FAKE_MODE", "False") == "True":
         values["fake_mode"] = True
+    fake_mode = values.get('fake_mode', False)
     use_venv = values.get("use_venv", True)
     nova_auth_url = str(values.get("nova_auth_url",
                                    "http://localhost:5000/v2.0"))


### PR DESCRIPTION
- Reddwarf conf can now use an extra file in scripts/conf/reddwarf.extra.conf.
- Test conf now is split into two files, so you can specify test.extra.conf with extra info.
- the hostname test enabled clause was modified.
