### PR TITLE
Made some changest to the RDLI tests to enable local fake mode testing.

### DIFF
--- a/scripts/conf/test_begin.conf
+++ b/scripts/conf/test_begin.conf
@@ -1,11 +1,19 @@
 {
     "dbaas_url":"http://localhost:8779/v1.0",
     "version_url":"http://localhost:8779",
-    "nova_auth_url":"http://localhost:35357/v2.0",
     "reddwarf_auth_url":"http://localhost:35357/v2.0/tokens",
     "reddwarf_client_insecure":false,
     "auth_strategy":null,
     "reddwarf_client_region_name": null,
+
+    "nova_client": {
+        "url":"http://localhost:8774/v1.1",
+        "auth_url":"http://localhost:35357/v2.0",
+        "nova_service_type":"compute",
+        "volume_service_type":"volume"
+    },
+
+    "flavors": null,
 
     "white_box":false,
     "start_services": true,
@@ -19,9 +27,7 @@
     "glance_image": "debian-squeeze-x86_64-openvz.tar.gz",
     "instance_flavor_name":"m1.rd-tiny",
     "instance_bigger_flavor_name":"m1.rd-smaller",
-    "nova_url":"http://localhost:8774/v1.1",
-    "nova_service_type":"compute",
-    "volume_service_type":"volume",
+
     "report_directory":"/integration/report",
     "nova_code_root":"/opt/stack/nova",
     "nova_conf":"/home/vagrant/nova.conf",

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -671,12 +671,22 @@ EOF
 }
 
 function init_fake_mode() {
-    CONF_FILE=$PATH_REDDWARF/etc/reddwarf/reddwarf.conf.test
+    # Create a test conf which, unlike the conf which runs on a user's machine,
+    # takes advantage of the running keystone service we have in our VM.
+    # You could think of this fake mode, which runs in the VM as being
+    # slightly less fake than the default one which runs outside of it.
+    CONF_FILE=/tmp/reddwarf.conf.test
+    cp $PATH_REDDWARF/etc/reddwarf/reddwarf.conf.test $CONF_FILE
+    # Switch keystone from the fake class to the real one.
+    sed -i \
+        "s/%reddwarf.tests.fakes.keystone%/keystone.middleware.auth_token/g" \
+        $CONF_FILE
     cd $PATH_REDDWARF
     set -e
     rm -f reddwarf_test.sqlite
     set +e
-    bin/reddwarf-manage --config-file=$CONF_FILE db_sync \
+    bin/reddwarf-manage --config-file=$CONF_FILE \
+        db_sync \
         repo_path=reddwarf_test.sqlite
     sqlite3 reddwarf_test.sqlite \
         "INSERT INTO service_images VALUES('1','mysql','fake');"
@@ -692,7 +702,7 @@ function cmd_start() {
 function cmd_start_fake() {
     init_fake_mode
     init_reddwarf_screen
-    CONF_FILE=$PATH_REDDWARF/etc/reddwarf/reddwarf.conf.test
+    CONF_FILE=/tmp/reddwarf.conf.test
     screen_it reddwarf "cd $PATH_REDDWARF; bin/reddwarf-api --config-file=$CONF_FILE $@ repo_path=reddwarf_test.sqlite"
 }
 
@@ -703,7 +713,7 @@ function cmd_run() {
 
 function cmd_run_fake() {
     init_fake_mode
-    CONF_FILE=$PATH_REDDWARF/etc/reddwarf/reddwarf.conf.test
+    CONF_FILE=/tmp/reddwarf.conf.test
     bin/reddwarf-api --config-file=$CONF_FILE $@ \
         repo_path=reddwarf_test.sqlite
 }

--- a/tests/integration/localhost.test.conf
+++ b/tests/integration/localhost.test.conf
@@ -1,0 +1,77 @@
+{
+    "dbaas_url":"http://localhost:8779/v1.0",
+    "version_url":"http://localhost:8779",
+    "nova_auth_url":"http://localhost:8779/v1.0/auth",
+    "reddwarf_auth_url":"http://localhost:8779/v1.0/auth",
+    "reddwarf_client_insecure":false,
+    "auth_strategy":"fake",
+
+    "reddwarf_version":"v1.0",
+
+    "nova_client": null,
+
+
+    "white_box":false,
+    "fake_mode":true,
+    "test_mgmt":false,
+    "use_local_ovz":false,
+    "use_venv":false,
+    "glance_api_conf":"/vagrant/conf/glance-api.conf",
+    "glance_reg_conf":"/vagrant/conf/glance-reg.conf",
+    "glance_images_directory": "/glance_images",
+    "glance_image": "debian-squeeze-x86_64-openvz.tar.gz",
+    "report_directory":"/home/tsimpson/TestReport",
+    "nova_code_root":"/opt/stack/nova",
+    "nova_conf":"/home/vagrant/nova.conf",
+    "keystone_code_root":"/opt/stack/keystone",
+    "keystone_conf":"/etc/keystone/keystone.conf",
+    "keystone_use_combined":true,
+    "reddwarf_code_root":"/opt/stack/reddwarf_lite",
+    "reddwarf_conf":"/tmp/reddwarf.conf",
+    "reddwarf_max_accepted_volume_size":128,
+    "reddwarf_must_have_volume":false,
+    "reddwarf_can_have_volume":true,
+    "reddwarf_main_instance_has_volume":true,
+    "use_reaper":false,
+    "users": [
+        {
+          "auth_user":"admin",
+          "auth_key":"password",
+          "tenant":"admin-1000",
+          "requirements": {
+            "is_admin":true,
+            "services": ["reddwarf"]
+          }
+        },
+        {
+          "auth_user":"jsmith",
+          "auth_key":"password",
+          "tenant":"2500",
+          "requirements": {
+            "is_admin":false,
+            "services": ["reddwarf"]
+          }
+        },
+        {
+          "auth_user":"hub_cap",
+          "auth_key":"password",
+          "tenant":"3000",
+          "requirements": {
+            "is_admin":false,
+            "services": ["reddwarf"]
+          }
+        }
+    ],
+    "root_removed_from_instance_api": true,
+    "root_timestamp_disabled": true,
+    "openvz_disabled": true,
+    "management_api_disabled": true,
+    "hostname_not_implemented": false,
+    "dbaas_image": "fake",
+
+    "reddwarf_dns_support": false,
+    "databases_page_size": 20,
+    "instances_page_size": 20,
+    "users_page_size": 20,
+    "rabbit_runs_locally":false
+}

--- a/tests/integration/tests/api/flavors.py
+++ b/tests/integration/tests/api/flavors.py
@@ -23,6 +23,7 @@ from reddwarfclient import exceptions
 from proboscis import before_class
 from proboscis import test
 from proboscis.asserts import assert_raises
+from proboscis import SkipTest
 
 import tests
 from tests.util import create_dbaas_client
@@ -90,6 +91,9 @@ class Flavors(object):
 
     @before_class
     def setUp(self):
+        if test_config.nova_client is None:
+            raise SkipTest("Skipping this test as no info to communicate with "
+                           "Nova was found in the test config.")
         nova_user = test_config.users.find_user(
             Requirements(is_admin=False, services=["nova"]))
         rd_user = test_config.users.find_user(

--- a/tests/integration/tests/api/instances.py
+++ b/tests/integration/tests/api/instances.py
@@ -187,7 +187,7 @@ class InstanceSetup(object):
         if WHITE_BOX:
             instance_info.nova_client = create_nova_client(instance_info.user)
             instance_info.volume_client = create_nova_client(instance_info.user,
-                                            service_type="volume_service_type")
+                    service_type=test_config.nova_client['volume_service_type'])
 
         dbaas = instance_info.dbaas
 
@@ -250,7 +250,7 @@ class InstanceSetup(object):
 
 
 @test(depends_on_classes=[InstanceSetup], groups=[GROUP])
-def test_delete_instance_not_found(self):
+def test_delete_instance_not_found():
     """Deletes an instance that does not exist."""
     # Looks for a random UUID that (most probably) does not exist.
     assert_raises(exceptions.NotFound, dbaas.instances.delete,

--- a/tests/integration/tests/api/mgmt/instances.py
+++ b/tests/integration/tests/api/mgmt/instances.py
@@ -12,7 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from novaclient import exceptions
+from reddwarfclient import exceptions
 
 from proboscis import before_class
 from proboscis import test

--- a/tests/integration/tests/initialize.py
+++ b/tests/integration/tests/initialize.py
@@ -47,7 +47,7 @@ def dbaas_url():
     return str(CONFIG.values.get("dbaas_url"))
 
 def nova_url():
-    return str(CONFIG.values.get("nova_url"))
+    return str(CONFIG.values.get("nova_client")['url'])
 
 
 

--- a/tests/integration/tests/util/users.py
+++ b/tests/integration/tests/util/users.py
@@ -27,6 +27,8 @@ class Requirements(object):
     def __init__(self, is_admin, services=None):
         self.is_admin = is_admin
         self.services = services or ["reddwarf"]
+        # Make sure they're all the same kind of string.
+        self.services = [str(service) for service in self.services]
 
     def satisfies(self, reqs):
         """True if these requirements conform to the given requirements."""
@@ -61,6 +63,17 @@ class ServiceUser(object):
         self.requirements = requirements
         self.test_count = 0
 
+    def __str__(self):
+        return "{ user_name=%s, tenant_id=%s, reqs=%s, tests=%d }" % (
+            self.auth_user, self.tenant_id, self.requirements, self.test_count)
+        self.auth_key = auth_key
+        self.tenant = tenant
+        self.tenant_id = tenant_id
+        self.requirements = requirements
+        self.test_count = 0
+
+
+
 
 class Users(object):
     """Collection of users with methods to find them via requirements."""
@@ -79,6 +92,15 @@ class Users(object):
     def find_all_users_who_satisfy(self, requirements, black_list=None):
         """Returns a list of all users who satisfy the given requirements."""
         black_list = black_list or []
+        print("Searching for a user who meets requirements %s in our list..."
+              % requirements)
+        print("Users:")
+        for user in self.users:
+            print("\t" + str(user))
+        print("Black list")
+        for item in black_list:
+            print("\t" + str(item))
+        black_list = black_list or []
         return (user for user in self.users
                 if user.auth_user not in black_list and
                 user.requirements.satisfies(requirements))
@@ -88,7 +110,7 @@ class Users(object):
         users = self.find_all_users_who_satisfy(requirements, black_list)
         try:
             user = min(users, key=lambda user: user.test_count)
-        except ValueError:
+        except ValueError:  # Raised when "users" is empty.
             raise RuntimeError("The test configuration data lacks a user "
                  "who meets these requirements: %s" % requirements)
         user.test_count += 1

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,23 +1,25 @@
-# content of: tox.ini , put in same dir as setup.py
+# Examples:
+# Run tests against Reddwarf running locally in fake mode:
+# tox -e local -- --group=blackbox
 [tox]
 envlist = py26
 
 [testenv]
-#commands=
-
-
-[testenv:py26]
 deps =
     coverage
     #eventlet
     nose
     pexpect
-    {env:NOVA_CLIENT_PATH}
-    proboscis==1.2.5.2
+    proboscis
     sqlalchemy
     {env:REDDWARF_CLIENT_PATH}
+
+[testenv:py26]
 commands =
     {envpython} int_tests.py {posargs:DEFAULTS}
 
+[testenv:local]
+commands =
+    {envpython} int_tests.py --conf=localhost.test.conf {posargs:DEFAULTS}
 
 


### PR DESCRIPTION
- Changed config file layout, so that all Nova client info is now in a dictionary under the "nova_client" key.
- Changed redstack's run-fake so that it creates a mod of the reddwarf.test.conf which takes advantage of the daemons setup in the VM (such as keystone).
- The flavors tests and any call to grab a nova client now raise SkipTest if "nova_client" is set to None in the test config. This allows for tests to run when the Nova services can't be reached.
- Fixed a bug with the "test_delete_instance_not_found" function which strangely had not been caught before.
- Changed a few places to not import nova client until the last possible moment (since in local mode it may not be imported at all).
- Changed the function to grab a Nova client to have a custom Authenticator which essentially ignores auth in local fake mode.
- Added extra prints to the users module, since it can be confusing when the user config is incorrect.
- Took nova client out of the tox file, and updated the proboscis version.
- Adding a test file that acts against a fake mode RDL server on localhost.
