### PR TITLE
Adds the ability to launch a Python repl in the test environment.

### DIFF
--- a/scripts/redstack
+++ b/scripts/redstack
@@ -940,6 +940,9 @@ function cmd_update_projects() {
   done
 }
 
+function cmd_repl() {
+    INT_TEST_OPTIONS=-i cmd_int_tests_white_box --repl --group=_does_not_exist_ $@
+}
 
 ###############################################################################
 # Process the user provided command and run the appropriate command
@@ -1045,6 +1048,7 @@ function run_command() {
         "reset-task" ) shift; cmd_reset_task $@;;
         "wipe-queues" ) shift; cmd_wipe_queues $@;;
         "example-tests" ) shift; cmd_example_tests $@;;
+        "repl" ) shift; cmd_repl $@;;
         * )
             echo "'$1' not a valid command"
             exit 1

--- a/tests/integration/int_tests.py
+++ b/tests/integration/int_tests.py
@@ -130,9 +130,9 @@ if __name__ == '__main__':
     index = 0
     while index < len(sys.argv):
         arg = sys.argv[index]
-        if arg[:2] == "-i" or arg == 'repl':
+        if arg[:2] == "-i" or arg == '--repl':
             repl = True
-        if arg[:7] == "--conf=":
+        elif arg[:7] == "--conf=":
             conf_file = os.path.expanduser(arg[7:])
             print("Setting TEST_CONF to " + conf_file)
             os.environ["TEST_CONF"] = conf_file


### PR DESCRIPTION
- This redstack command lets you play in the Python environment stood up
  by the tests with access to both the test and source code. Convenient
  for testing bits of code directly.
