### PR TITLE
Making RDLI work in other environments.

### DIFF
--- a/tests/integration/tests/api/mgmt/accounts.py
+++ b/tests/integration/tests/api/mgmt/accounts.py
@@ -28,6 +28,7 @@ from tests.api.instances import instance_info
 from tests.util import test_config
 from tests.util import create_dbaas_client
 from tests.util.users import Requirements
+from tests.api.instances import existing_instance
 
 GROUP = "dbaas.api.mgmt.accounts"
 
@@ -55,7 +56,8 @@ class AccountsBeforeInstanceCreation(object):
     @test
     def test_account_zero_instances(self):
         account_info = self.client.accounts.show(self.user.tenant_id)
-        assert_equal(0, len(account_info.instances))
+        expected_instances = 0 if not existing_instance() else 1
+        assert_equal(expected_instances, len(account_info.instances))
         expected = self.user.tenant_id
         if expected is None:
             expected = "None"
@@ -64,7 +66,8 @@ class AccountsBeforeInstanceCreation(object):
     @test
     def test_list_empty_accounts(self):
         accounts_info = self.client.accounts.index()
-        assert_equal(0, len(accounts_info.accounts))
+        expected_accounts = 0 if not existing_instance() else 1
+        assert_equal(expected_accounts, len(accounts_info.accounts))
 
 
 @test(groups=[tests.INSTANCES, GROUP], depends_on_groups=["dbaas.listing"])

--- a/tests/integration/tests/api/mgmt/hosts.py
+++ b/tests/integration/tests/api/mgmt/hosts.py
@@ -61,7 +61,7 @@ class HostsBeforeInstanceCreation(object):
             print("%r host: %r" % (host[0], host[1]))
             self.host = host[1]
 
-    @test(enabled=create_new_instance())
+    @test(enabled=create_new_instance(), depends_on=[test_empty_index_host_list])
     def test_empty_index_host_list_single(self):
         single_host = self.client.hosts.get(self.host)
         assert_not_equal(single_host, None,

--- a/tests/integration/tests/config.py
+++ b/tests/integration/tests/config.py
@@ -61,6 +61,7 @@ class TestConfig(object):
             'nova_url': "http://localhost:8774/v1.1",
             'instance_create_time': 16 * 60,
             'dbaas_image': None,
+            'mysql_connection_method': {"type": "direct"},
             'typical_nova_image_name': None,
             'white_box': False,
             'test_mgmt': False,

--- a/tests/integration/tests/util/mysql.py
+++ b/tests/integration/tests/util/mysql.py
@@ -1,0 +1,155 @@
+import pexpect
+import re
+from sqlalchemy import create_engine
+from tests.config import CONFIG
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import ResourceClosedError
+
+
+def create_mysql_connection(host, user, password):
+    connection = CONFIG.mysql_connection_method
+    if connection['type'] == "direct":
+        return SqlAlchemyConnection(host, user, password)
+    elif connection['type'] == "tunnel":
+        if 'ssh' not in connection:
+            raise RuntimeError("If connection type is 'tunnel' then a "
+                               "property 'ssh' is expected.")
+        return PexpectMySqlConnection(connection['ssh'], host, user, password)
+    else:
+        raise RuntimeError("Unknown justBad test configuration for mysql_connection_method")
+
+
+class MySqlConnectionFailure(RuntimeError):
+
+    def __init__(self, msg):
+        super(MySqlConnectionFailure, self).__init__(msg)
+
+
+class MySqlPermissionsFailure(RuntimeError):
+
+    def __init__(self, msg):
+        super(MySqlPermissionsFailure, self).__init__(msg)
+
+
+class SqlAlchemyConnection(object):
+
+    def __init__(self, host, user, password):
+        self.host = host
+        self.user = user
+        self.password = password
+        try:
+            self.engine = self._init_engine(user, password, host)
+        except OperationalError as oe:
+            if self._exception_is_permissions_issue(oe.message):
+                raise MySqlPermissionsFailure(oe)
+            else:
+                raise MySqlConnectionFailure(original)
+
+    @staticmethod
+    def _exception_is_permissions_issue(msg):
+        """Assert a message cited a permissions issue and not something else."""
+        pos_error = re.compile(".*Host '[\w\.]*' is not allowed to connect to "
+                               "this MySQL server.*")
+        pos_error1 = re.compile(".*Access denied for user "
+                                "'[\w\*\!\@\#\^\&]*'@'[\w\.]*'.*")
+        if (pos_error.match(msg) or pos_error1.match(msg)):
+            return True
+
+    def __enter__(self):
+        try:
+            self.conn = self.engine.connect()
+        except OperationalError as oe:
+            if self._exception_is_permissions_issue(oe.message):
+                raise MySqlPermissionsFailure(oe)
+            else:
+                raise MySqlConnectionFailure(original)
+        self.trans = self.conn.begin()
+        return self
+
+    def execute(self, cmd):
+        """Execute some code."""
+        cmd = cmd.replace("%", "%%")
+        try:
+            return self.conn.execute(cmd).fetchall()
+        except:
+            self.trans.rollback()
+            self.trans = None
+            try:
+                raise
+            except ResourceClosedError:
+                return []
+
+    def __exit__(self, type, value, traceback):
+        if self.trans:
+            if type is not None:  # An error occurred
+                self.trans.rollback()
+            else:
+                self.trans.commit()
+        self.conn.close()
+
+    @staticmethod
+    def _init_engine(user, password, host):
+        return create_engine("mysql://%s:%s@%s:3306" % (user, password, host),
+                             pool_recycle=1800, echo=True)
+
+
+class PexpectMySqlConnection(object):
+
+    TIME_OUT = 30
+
+    def __init__(self, ssh_args, host, user, password):
+        self.host = host
+        self.user = user
+        self.password = password
+        cmd = 'ssh %s' % ssh_args
+        self.proc = pexpect.spawn(cmd)
+        print(cmd)
+        self.proc.expect(":~\$", timeout=self.TIME_OUT)
+        cmd2 = "mysql --host '%s' -u '%s' '-p%s'\n" % \
+               (self.host, self.user, self.password)
+        print(cmd2)
+        self.proc.send(cmd2)
+        result = self.proc.expect([
+            'mysql>',
+            'Access denied',
+            "Can't connect to MySQL server"],
+            timeout=self.TIME_OUT)
+        if result == 1:
+            raise MySqlPermissionsFailure(self.proc.before)
+        elif result == 2:
+            raise MySqlConnectionFailure(self.proc.before)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.proc.close()
+
+    def execute(self, cmd):
+        self.proc.send(cmd + "\G\n");
+        outcome = self.proc.expect(['Empty set', 'mysql>'],
+                                  timeout=self.TIME_OUT)
+        if outcome == 0:
+            return []
+        else:
+            # This next line might be invaluable for long test runs.
+            print("interpretting output: %s" % self.proc.before)
+            lines = self.proc.before.split("\r\n")
+            result = []
+            row = None
+            for line in lines:
+                plural_s = "s" if len(result) != 0 else ""
+                end_line = "%d row%s in set" % ((len(result) + 1), plural_s)
+                if len(result) == 0:
+                    end_line = "1 row in set"
+                if (line.startswith("***************************") or
+                    line.startswith(end_line)):
+                    if row is not None:
+                        result.append(row)
+                    row = {}
+                elif row is not None:
+                    colon = line.find(": ")
+                    field = line[:colon]
+                    value = line[colon + 2:]
+                    row[field] = value
+            return result

--- a/tests/integration/tests/util/users.py
+++ b/tests/integration/tests/util/users.py
@@ -116,12 +116,20 @@ class Users(object):
         user.test_count += 1
         return user
 
-    def find_user_by_name(self, name):
-        """Finds a user who meets the requirements and has been used least."""
-        users = (user for user in self.users if user.auth_user == name)
+    def _find_user_by_condition(self, condition):
+        users = (user for user in self.users if condition(user))
         try:
             user = min(users, key=lambda user: user.test_count)
         except ValueError:
             raise RuntimeError('Did not find a user with name "%s".' % name)
         user.test_count += 1
         return user
+
+    def find_user_by_name(self, name):
+        """Finds a user who meets the requirements and has been used least."""
+        condition = lambda user : user.auth_user == name
+        return self._find_user_by_condition(condition)
+
+    def find_user_by_tenant_id(self, tenant_id):
+        condition = lambda user : user.tenant_id == tenant_id
+        return self._find_user_by_condition(condition)


### PR DESCRIPTION
- Changed code to get instance IP addresses.
- Made the sql query code work even when we have to ssh to another box
  to do it. (?!)
- Fixed some accounts API function tests to work with the "instance
  already exists" environment variable.
- Fixed a bug where the client used for a pre-created instance is not
  created using the right user.
- Changed a few places where we query MySql directly to be compatable
  with both local MySQL and the new Pexpect version.
