### PR TITLE
Make sure that not only are the instance fields present, but non-null...

### DIFF
--- a/tests/integration/tests/api/mgmt/hosts.py
+++ b/tests/integration/tests/api/mgmt/hosts.py
@@ -142,3 +142,5 @@ class HostsAfterInstanceCreation(object):
                 check.equal(sorted(['id', 'name', 'status', 'server_id',
                                     'tenant_id']),
                             sorted(instance.keys()))
+                for key in instance.keys():
+                    check.is_not_none(instance[key])


### PR DESCRIPTION
...especially server_id and status.
What I'd like to do is have a handle on the list of all valid statuses and compare instance.status against that, but short of carting that list over by hand I think I'm SOL without importing the tasks model.
